### PR TITLE
Conclude connection success only once the system starts using the tunnel

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -484,8 +484,6 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
     
     /// :nodoc:
     public func sessionDidStart(_ session: OpenVPNSession, remoteAddress: String, options: OpenVPN.Configuration) {
-        reasserting = false
-        
         log.info("Session did start")
         
         log.info("Returned ifconfig parameters:")
@@ -522,6 +520,8 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
         }
 
         bringNetworkUp(remoteAddress: remoteAddress, localOptions: session.configuration, options: options) { (error) in
+            self.reasserting = false
+            
             if let error = error {
                 log.error("Failed to configure tunnel: \(error)")
                 self.pendingStartHandler?(error)


### PR DESCRIPTION
I found a leak in the time between the session starting and the system bringing the network up. The system only starts using the VPN tunnel once `bringNetworkUp` is called, and therefor the VPN connection status shouldn't be updated until the conclusion of this asynchronous call.