### PR TITLE
Do not clear reasserting flag when connection is not recoverable

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -579,6 +579,18 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
     public func sessionDidStop(_: OpenVPNSession, shouldReconnect: Bool) {
         log.info("Session did stop")
 
+        stopSession(shouldReconnect: shouldReconnect)
+    }
+    
+    /// :nodoc:
+    public func sessionFailed(_: OpenVPNSession, error: Error) {
+        log.info("Session failed")
+        
+        cancelTunnelWithError(error)
+        stopSession(shouldReconnect: false)
+    }
+    
+    private func stopSession(shouldReconnect: Bool) {
         isCountingData = false
         refreshDataCount()
 

--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -576,21 +576,14 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
     }
     
     /// :nodoc:
-    public func sessionDidStop(_: OpenVPNSession, shouldReconnect: Bool) {
-        log.info("Session did stop")
+    public func sessionDidStop(_: OpenVPNSession, withError error: Error?, shouldReconnect: Bool) {
+        if let error = error {
+            log.error("Session did stop with error: \(error)")
+            cancelTunnelWithError(error)
+        } else {
+            log.info("Session did stop")
+        }
 
-        stopSession(shouldReconnect: shouldReconnect)
-    }
-    
-    /// :nodoc:
-    public func sessionFailed(_: OpenVPNSession, error: Error) {
-        log.info("Session failed")
-        
-        cancelTunnelWithError(error)
-        stopSession(shouldReconnect: false)
-    }
-    
-    private func stopSession(shouldReconnect: Bool) {
         isCountingData = false
         refreshDataCount()
 

--- a/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -59,6 +59,11 @@ public protocol OpenVPNSessionDelegate: class {
      - Seealso: `OpenVPNSession.reconnect(...)`
      */
     func sessionDidStop(_: OpenVPNSession, shouldReconnect: Bool)
+    
+    /**
+     Called after a session failed to start.
+     */
+    func sessionFailed(_: OpenVPNSession, error: Error)
 }
 
 /// Provides methods to set up and maintain an OpenVPN session.
@@ -1275,13 +1280,15 @@ public class OpenVPNSession: Session {
     }
     
     private func doShutdown(error: Error?) {
+        stopError = error
+        
         if let error = error {
             log.error("Trigger shutdown (error: \(error))")
+            delegate?.sessionFailed(self, error: error)
         } else {
             log.info("Trigger shutdown on request")
+            delegate?.sessionDidStop(self, shouldReconnect: false)
         }
-        stopError = error
-        delegate?.sessionDidStop(self, shouldReconnect: false)
     }
     
     private func doReconnect(error: Error?) {

--- a/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -55,15 +55,11 @@ public protocol OpenVPNSessionDelegate: class {
     /**
      Called after stopping a session.
      
+     - Parameter error: An optional `Error` being the reason of the stop.
      - Parameter shouldReconnect: When `true`, the session can/should be restarted. Usually because the stop reason was recoverable.
      - Seealso: `OpenVPNSession.reconnect(...)`
      */
-    func sessionDidStop(_: OpenVPNSession, shouldReconnect: Bool)
-    
-    /**
-     Called after a session failed to start.
-     */
-    func sessionFailed(_: OpenVPNSession, error: Error)
+    func sessionDidStop(_: OpenVPNSession, withError error: Error?, shouldReconnect: Bool)
 }
 
 /// Provides methods to set up and maintain an OpenVPN session.
@@ -1280,15 +1276,13 @@ public class OpenVPNSession: Session {
     }
     
     private func doShutdown(error: Error?) {
-        stopError = error
-        
         if let error = error {
             log.error("Trigger shutdown (error: \(error))")
-            delegate?.sessionFailed(self, error: error)
         } else {
             log.info("Trigger shutdown on request")
-            delegate?.sessionDidStop(self, shouldReconnect: false)
         }
+        stopError = error
+        delegate?.sessionDidStop(self, withError: error, shouldReconnect: false)
     }
     
     private func doReconnect(error: Error?) {
@@ -1298,6 +1292,6 @@ public class OpenVPNSession: Session {
             log.info("Trigger reconnection on request")
         }
         stopError = error
-        delegate?.sessionDidStop(self, shouldReconnect: true)
+        delegate?.sessionDidStop(self, withError: error, shouldReconnect: true)
     }
 }


### PR DESCRIPTION
### Issue I'm trying to solve
When attempting to connect, if there is an auth failure, the host application receives a `connected` status update from the extension before receiving a `disconnected` update, which leads to confusing UI changes and poor handling of the error state (in my case checking for an update in the user's VPN credentials).

### What triggers the transient connected state
Setting NETunnelProvider's `reasserting` to false triggers a successful connection status from from OS.

### Proposed solution
According to NEPacketTunnelProvider's docs, upon error, `cancelTunnelWithError(_:)` should be called: https://developer.apple.com/documentation/networkextension/nepackettunnelprovider/1406169-canceltunnelwitherror.
This PR proposes calling `cancelTunnelWithError(_:)` before reseting state in `OpenVPNTunnelProvider`.

This solution resolves the specific problem described above, but I'm not confident as to the lack of side effects. I'm also not sure the implications of calling `cancelTunnelWithError(_:)` from the error case in `doReconnect`. Any guidance or recommendations would be appreciated.