### PR TITLE
Add support for net_gateway keyword and client-side routes

### DIFF
--- a/TunnelKit/Sources/Core/IPv4Settings.swift
+++ b/TunnelKit/Sources/Core/IPv4Settings.swift
@@ -65,6 +65,16 @@ public struct IPv4Settings: Codable, CustomStringConvertible {
     
     /// The additional routes.
     public let routes: [Route]
+
+    /// :nodoc:
+    public static func deserialized(_ data: Data) throws -> IPv4Settings {
+        return try JSONDecoder().decode(IPv4Settings.self, from: data)
+    }
+    
+    /// :nodoc:
+    public func serialized() -> Data? {
+        return try? JSONEncoder().encode(self)
+    }
     
     // MARK: CustomStringConvertible
     

--- a/TunnelKit/Sources/Core/IPv4Settings.swift
+++ b/TunnelKit/Sources/Core/IPv4Settings.swift
@@ -66,6 +66,11 @@ public struct IPv4Settings: Codable, CustomStringConvertible {
     /// The additional routes.
     public let routes: [Route]
 
+    /// Returns true if this instance contains settings.
+    public var hasSettings: Bool {
+        return !address.isEmpty
+    }
+
     /// :nodoc:
     public static func deserialized(_ data: Data) throws -> IPv4Settings {
         return try JSONDecoder().decode(IPv4Settings.self, from: data)

--- a/TunnelKit/Sources/Core/IPv6Settings.swift
+++ b/TunnelKit/Sources/Core/IPv6Settings.swift
@@ -65,6 +65,16 @@ public struct IPv6Settings: Codable, CustomStringConvertible {
     
     /// The additional routes.
     public let routes: [Route]
+
+    /// :nodoc:
+    public static func deserialized(_ data: Data) throws -> IPv6Settings {
+        return try JSONDecoder().decode(IPv6Settings.self, from: data)
+    }
+    
+    /// :nodoc:
+    public func serialized() -> Data? {
+        return try? JSONEncoder().encode(self)
+    }
     
     // MARK: CustomStringConvertible
     

--- a/TunnelKit/Sources/Core/IPv6Settings.swift
+++ b/TunnelKit/Sources/Core/IPv6Settings.swift
@@ -66,6 +66,11 @@ public struct IPv6Settings: Codable, CustomStringConvertible {
     /// The additional routes.
     public let routes: [Route]
 
+    /// Returns true if this instance contains settings.
+    public var hasSettings: Bool {
+        return !address.isEmpty
+    }
+
     /// :nodoc:
     public static func deserialized(_ data: Data) throws -> IPv6Settings {
         return try JSONDecoder().decode(IPv6Settings.self, from: data)

--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider+Configuration.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider+Configuration.swift
@@ -175,6 +175,10 @@ extension OpenVPNTunnelProvider {
             
             static let usesPIAPatches = "UsesPIAPatches"
             
+            static let ipv4 = "IPv4"
+            
+            static let ipv6 = "IPv6"
+            
             static let dnsServers = "DNSServers"
             
             static let searchDomains = "SearchDomains"
@@ -516,6 +520,20 @@ private extension OpenVPN.Configuration {
         if let usesPIAPatches = providerConfiguration[S.usesPIAPatches] as? Bool {
             builder.usesPIAPatches = usesPIAPatches
         }
+        if let ipv4Data = providerConfiguration[S.ipv4] as? Data {
+            do {
+                builder.ipv4 = try IPv4Settings.deserialized(ipv4Data)
+            } catch {
+                throw E.parameter(name: "protocolConfiguration.providerConfiguration[\(S.ipv4)]")
+            }
+        }
+        if let ipv6Data = providerConfiguration[S.ipv6] as? Data {
+            do {
+                builder.ipv6 = try IPv6Settings.deserialized(ipv6Data)
+            } catch {
+                throw E.parameter(name: "protocolConfiguration.providerConfiguration[\(S.ipv6)]")
+            }
+        }
         if let dnsServers = providerConfiguration[S.dnsServers] as? [String] {
             builder.dnsServers = dnsServers
         }
@@ -595,6 +613,12 @@ private extension OpenVPN.Configuration {
         }
         if let usesPIAPatches = usesPIAPatches {
             dict[S.usesPIAPatches] = usesPIAPatches
+        }
+        if let ipv4Data = ipv4?.serialized() {
+            dict[S.ipv4] = ipv4Data
+        }
+        if let ipv6Data = ipv6?.serialized() {
+            dict[S.ipv6] = ipv6Data
         }
         if let dnsServers = dnsServers {
             dict[S.dnsServers] = dnsServers

--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -561,14 +561,38 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
         socket?.shutdown()
     }
     
+    private func applicableIPv4Settings(localOptions: OpenVPN.Configuration, options: OpenVPN.Configuration) -> IPv4Settings? {
+        if options.ipv4?.hasSettings ?? false {
+            return options.ipv4;
+        }
+
+        if localOptions.ipv4?.hasSettings ?? false {
+            return localOptions.ipv4;
+        }
+
+        return nil
+    }
+
+    private func applicableIPv6Settings(localOptions: OpenVPN.Configuration, options: OpenVPN.Configuration) -> IPv6Settings? {
+        if options.ipv6?.hasSettings ?? false {
+            return options.ipv6;
+        }
+
+        if localOptions.ipv6?.hasSettings ?? false {
+            return localOptions.ipv6;
+        }
+
+        return nil
+    }
+
     private func bringNetworkUp(remoteAddress: String, localOptions: OpenVPN.Configuration, options: OpenVPN.Configuration, completionHandler: @escaping (Error?) -> Void) {
         let routingPolicies = localOptions.routingPolicies ?? options.routingPolicies
         let isIPv4Gateway = routingPolicies?.contains(.IPv4) ?? false
         let isIPv6Gateway = routingPolicies?.contains(.IPv6) ?? false
         let isGateway = isIPv4Gateway || isIPv6Gateway
-
+        
         var ipv4Settings: NEIPv4Settings?
-        if let ipv4 = (options.ipv4 ?? localOptions.ipv4) {
+        if let ipv4 = applicableIPv4Settings(localOptions: localOptions, options: options) {
             var includedRoutes: [NEIPv4Route] = []
             var excludedRoutes: [NEIPv4Route] = []
 
@@ -607,7 +631,7 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
         }
 
         var ipv6Settings: NEIPv6Settings?
-        if let ipv6 = (options.ipv6 ?? localOptions.ipv6) {
+        if let ipv6 = applicableIPv6Settings(localOptions: localOptions, options: options) {
             var routes: [NEIPv6Route] = []
 
             // route all traffic to VPN?

--- a/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
@@ -222,7 +222,7 @@ extension OpenVPN {
             var optIfconfig4Arguments: [String]?
             var optIfconfig6Arguments: [String]?
             var optGateway4Arguments: [String]?
-            var optRoutes4: [(String, String, String?)] = [] // address, netmask, gateway
+            var optRoutes4: [(String, String, String)] = [] // address, netmask, gateway
             var optRoutes6: [(String, UInt8, String?)] = [] // destination, prefix, gateway
             var optDNSServers: [String]?
             var optSearchDomains: [String]?
@@ -703,12 +703,22 @@ extension OpenVPN {
                     addressMask4 = "255.255.255.255"
                     defaultGateway4 = ifconfig4Arguments[1]
                 }
-                let routes4 = optRoutes4.map { IPv4Settings.Route($0.0, $0.1, $0.2 ?? defaultGateway4) }
+                let routes4 = optRoutes4.map { IPv4Settings.Route($0.0, $0.1, $0.2) }
 
                 sessionBuilder.ipv4 = IPv4Settings(
                     address: address4,
                     addressMask: addressMask4,
                     defaultGateway: defaultGateway4,
+                    routes: routes4
+                )
+            } else if !optRoutes4.isEmpty {
+                // Still want to include routes when ifconfig is not specified 
+                let routes4 = optRoutes4.map { IPv4Settings.Route($0.0, $0.1, $0.2) }
+
+                sessionBuilder.ipv4 = IPv4Settings(
+                    address: "",
+                    addressMask: "",
+                    defaultGateway: "",
                     routes: routes4
                 )
             }

--- a/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
@@ -86,7 +86,7 @@ extension OpenVPN {
             
             static let ifconfig6 = NSRegularExpression("^ifconfig-ipv6 +[\\da-fA-F:]+/\\d+ [\\da-fA-F:]+")
             
-            static let route = NSRegularExpression("^route +[\\d\\.]+( +[\\d\\.]+){0,2}")
+            static let route = NSRegularExpression("^route +[\\d\\.]+( +[\\d\\.]+)( +[\\d\\.]+| vpn_gateway| net_gateway)")
             
             static let route6 = NSRegularExpression("^route-ipv6 +[\\da-fA-F:]+/\\d+( +[\\da-fA-F:]+){0,2}")
             
@@ -491,10 +491,7 @@ extension OpenVPN {
                     
                     let address = routeEntryArguments[0]
                     let mask = (routeEntryArguments.count > 1) ? routeEntryArguments[1] : "255.255.255.255"
-                    var gateway = (routeEntryArguments.count > 2) ? routeEntryArguments[2] : nil // defaultGateway4
-                    if gateway == "vpn_gateway" {
-                        gateway = nil
-                    }
+                    let gateway = (routeEntryArguments.count > 2) ? routeEntryArguments[2] : "vpn_gateway"
                     optRoutes4.append((address, mask, gateway))
                 }
                 Regex.route6.enumerateArguments(in: line) {


### PR DESCRIPTION
This adds support for specifying `net_gateway` for a route's gateway, which will route traffic over the device's default gateway rather than the VPN. It also addresses an issue where routes specified in the client profile would not be added when the tunnel goes up.