### PR TITLE
Fixed "Index out of range" bug in control channel

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/ControlChannel.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/ControlChannel.swift
@@ -199,7 +199,7 @@ extension OpenVPN {
             }
             
             // drop queued out packets if ack-ed
-            for (i, packet) in queue.outbound.enumerated() {
+            for (i, packet) in queue.outbound.enumerated().reversed() {
                 if packetIds.contains(packet.packetId) {
                     queue.outbound.remove(at: i)
                 }


### PR DESCRIPTION
Hi there!

**The bug story**

I've tried to establish a VPN connection from iOS device to my test VPN server with SoftEther on board. SoftEhter declares, that it supports openvpn protocol (and it really does).  
However, when I built and setup all things, soon after connection in the Demo app, I got a disconnected state. 
I've analyzed the logs, and it seems that at some moment of time the runtime error "Index out of range" occures inside network extension, which causes network session daemon to unload this extension and drop connection. 
After adding some debug logs I found a place with the problem: we are iterating the queue with packets, deleting the packet from it at the same time. So after deleting we have a problem with array indexes. 

**The fix**
This is a well-known problem, and as far as I could say, in Swift the common solution is to iterate over reversed array, so index changing would not affect any next elements, which I implemented here.