### PR TITLE
Draft: Reconnect based on path monitor

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -130,6 +130,10 @@ open class OpenVPNTunnelProvider: NEPacketTunnelProvider {
     
     private var shouldReconnect = false
 
+    // Bookkeeping and path monitor for wait and reconnect
+    private var shouldReconnectWhenNetworkBecomesAvailable = false
+    private var reconnectionPathMonitor: AnyObject?
+
     // MARK: NEPacketTunnelProvider (XPC queue)
     
     open override var reasserting: Bool {
@@ -412,6 +416,51 @@ open class OpenVPNTunnelProvider: NEPacketTunnelProvider {
         }
         defaults?.dataCountArray = [dataCount.0, dataCount.1]
     }
+
+    deinit {
+        if #available(iOS 12, macOS 10.14, *) {
+            tearDownReconnectionPathMonitor()
+        }
+    }
+}
+
+@available(iOS 12, macOS 10.14, *)
+extension OpenVPNTunnelProvider {
+
+    // MARK: Wait and reconnect
+
+    // If reconnecting based on path monitor is enabled, a NWPathMonitor is used
+    // to trigger reconnection to recover from a link failure or network change.
+    public func setReconnectBasedOnPathMonitor(enabled: Bool) {
+        if enabled {
+            setUpReconnectionPathMonitor()
+        } else {
+            tearDownReconnectionPathMonitor()
+        }
+    }
+
+    // Setup reconnectionPathMonitor to reconnect (if asked to) when network comes up next
+    public func setUpReconnectionPathMonitor() {
+        let pathMonitor = NWPathMonitor()
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            guard let self = self else { return }
+            log.debug("reconnectionPathMonitor path status = \(path.status), interfaces = \(path.availableInterfaces)")
+            if path.status == .satisfied && self.shouldReconnectWhenNetworkBecomesAvailable {
+                self.shouldReconnectWhenNetworkBecomesAvailable = false
+                self.connectTunnel()
+            }
+        }
+        pathMonitor.start(queue: DispatchQueue.main)
+        reconnectionPathMonitor = pathMonitor
+    }
+
+    // Tear down and deref reconnectionPathMonitor
+    private func tearDownReconnectionPathMonitor() {
+        if let pathMonitor = reconnectionPathMonitor as? NWPathMonitor {
+            pathMonitor.cancel()
+        }
+        reconnectionPathMonitor = nil
+    }
 }
 
 extension OpenVPNTunnelProvider: GenericSocketDelegate {
@@ -481,6 +530,20 @@ extension OpenVPNTunnelProvider: GenericSocketDelegate {
 
         // reconnect?
         if shouldReconnect {
+
+            if #available(iOS 12, macOS 10.14, *) {
+                if shutdownError as? ProviderError == .networkChanged,
+                    let pathMonitor = self.reconnectionPathMonitor as? NWPathMonitor,
+                    pathMonitor.currentPath.status == .unsatisfied {
+                    // If the network path is in the process of changing, and we don't currently
+                    // have a path yet, wait till a path becomes available and then reconnect.
+                    log.debug("Tunnel will reconnect shortly, after a network interface becomes available")
+                    self.shouldReconnectWhenNetworkBecomesAvailable = true
+                    self.reasserting = true
+                    return
+                }
+            }
+
             log.debug("Disconnection is recoverable, tunnel will reconnect in \(reconnectionDelay) milliseconds...")
             tunnelQueue.schedule(after: .milliseconds(reconnectionDelay)) {
 
@@ -494,6 +557,14 @@ extension OpenVPNTunnelProvider: GenericSocketDelegate {
                 self.reasserting = true
                 self.connectTunnel(upgradedSocket: upgradedSocket)
             }
+            return
+        }
+
+        // reconnect later
+        if self.reconnectionPathMonitor != nil && (shutdownError as? OpenVPNError == .failedLinkWrite) {
+            log.debug("Disconnection can't be recovered at present, tunnel will reconnect when network becomes available")
+            self.shouldReconnectWhenNetworkBecomesAvailable = true
+            self.reasserting = true
             return
         }
 


### PR DESCRIPTION
In case the network goes down (say, wifi and cellular were turned off) while the tunnel is up, currently the tunnel process shuts down and exits. With this PR, the tunnel process would wait until the network becomes available, and then try to reconnect, all the while being in the reasserting state.

**Implementation**

This PR introduces a `setReconnectBasedOnPathMonitor` function, made available from iOS 12 / macOS Mojave onwards. Calling `setReconnectBasedOnPathMonitor(enabled: true)` enables the following:

 1. When the network goes down, the tunnel waits for the network to be back up, and then tries to reconnect. (Normally, the tunnel shuts down.)
 2. When a network change happens, the tunnel waits for the network to be back up using the network path monitor, and then tries to reconnect. (Normally, the tunnel tries to reconnect after 1s.)

The detection of when network becomes available is implemented using `NWPathMonitor`, which is available only from iOS 12 / macOS Mojave onwards.

`setReconnectBasedOnPathMonitor` can be called from a using app's tunnel extension code, like this:

```
class PacketTunnelProvider: OpenVPNTunnelProvider {
    override init() {
        super.init()
        super.setReconnectBasedOnPathMonitor(enabled: true)
    }
}
```

**Relation to On-Demand**

Per my understanding, because TunnelKit currently doesn't internally handle the scenario where the link goes down and then back up, users of TunnelKit are forced to always set `isOnDemandEnabled` to true (in which case the OS would call startTunnel() / stopTunnel() when the network goes up / down). With this PR, this scenario should be handled correctly whether `isOnDemandEnabled` is set or not set, so it enables users of TunnelKit to use the tunnel without On-Demand.

Using On-Demand all the time is a problem because when the tunnel fails, the OS keeps trying to turn on the tunnel -- that's appropriate in certain scenarios (say, network changed), but not appropriate in other scenarios (say, credentials are no longer valid).