### PR TITLE
Set IV_PLAT based on current OS

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/CoreConfiguration+OpenVPN.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/CoreConfiguration+OpenVPN.swift
@@ -64,9 +64,15 @@ extension CoreConfiguration {
         // MARK: Authentication
         
         static let peerInfo: String = {
+            let platform: String
+            #if os(iOS)
+            platform = "ios"
+            #else
+            platform = "mac"
+            #endif
             var info = [
                 "IV_VER=2.4",
-                "IV_PLAT=mac",
+                "IV_PLAT=\(platform)",
                 "IV_UI_VER=\(identifier) \(version)",
                 "IV_PROTO=2",
                 "IV_NCP=2",


### PR DESCRIPTION
Since this framework works on iOS and macOS, it seems weird that everything report as `mac` clients.