### PR TITLE
StandardVPNProvider renamed

### DIFF
--- a/Demo/BasicTunnel-iOS/ViewController.swift
+++ b/Demo/BasicTunnel-iOS/ViewController.swift
@@ -47,7 +47,7 @@ class ViewController: UIViewController, URLSessionDataDelegate {
 
     @IBOutlet var textLog: UITextView!
 
-    private let vpn = StandardVPNProvider(bundleIdentifier: tunnelIdentifier)
+    private let vpn = OpenVPNProvider(bundleIdentifier: tunnelIdentifier)
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Demo/BasicTunnel-macOS/ViewController.swift
+++ b/Demo/BasicTunnel-macOS/ViewController.swift
@@ -44,7 +44,7 @@ class ViewController: NSViewController {
     
     @IBOutlet var buttonConnection: NSButton!
     
-    private let vpn = StandardVPNProvider(bundleIdentifier: tunnelIdentifier)
+    private let vpn = OpenVPNProvider(bundleIdentifier: tunnelIdentifier)
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Provides a layer on top of the NetworkExtension framework. Most importantly, bri
 This subspec includes convenient classes to control the VPN tunnel from your app without the NetworkExtension headaches. Have a look at `VPNProvider` implementations:
 
 - `MockVPNProvider` (default, useful to test on simulator)
-- `StandardVPNProvider`
+- `OpenVPNProvider`
 
 Set `VPN.shared` to either of them at app launch time.
 


### PR DESCRIPTION
Just renamed StandardVPNProvider to OpenVPNProvider in Demo app (iOS & Mac) and in README file.

Great job, thank you!.
