### PR TITLE
Parse DOMAIN-SEARCH option

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
@@ -531,15 +531,10 @@ extension OpenVPN {
                     optDNSServers?.append($0[1])
                 }
                 Regex.domain.enumerateArguments(in: line) {
-                    guard $0.count == 2, optDomain == nil else {
+                    guard $0.count == 2 else {
                         return
                     }
                     optDomain = $0[1]
-                    if optSearchDomains == nil {
-                        optSearchDomains = [optDomain!]
-                    } else {
-                        optSearchDomains?.insert(optDomain!, at: 0)
-                    }
                 }
                 Regex.domainSearch.enumerateArguments(in: line) {
                     guard $0.count == 2 else {
@@ -763,6 +758,15 @@ extension OpenVPN {
                 )
             }
             
+            // prepend search domains with main domain (if set)
+            if let domain = optDomain {
+                if optSearchDomains == nil {
+                    optSearchDomains = [domain]
+                } else {
+                    optSearchDomains?.insert(domain, at: 0)
+                }
+            }
+
             sessionBuilder.dnsServers = optDNSServers
             sessionBuilder.searchDomains = optSearchDomains
             sessionBuilder.httpProxy = optHTTPProxy

--- a/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/ConfigurationParser.swift
@@ -96,6 +96,8 @@ extension OpenVPN {
             
             static let domain = NSRegularExpression("^dhcp-option +DOMAIN +[^ ]+")
             
+            static let domainSearch = NSRegularExpression("^dhcp-option +DOMAIN-SEARCH +[^ ]+")
+            
             static let proxy = NSRegularExpression("^dhcp-option +PROXY_(HTTPS? +[^ ]+ +\\d+|AUTO_CONFIG_URL +[^ ]+)")
             
             static let proxyBypass = NSRegularExpression("^dhcp-option +PROXY_BYPASS +.+")
@@ -225,6 +227,7 @@ extension OpenVPN {
             var optRoutes4: [(String, String, String?)] = [] // address, netmask, gateway
             var optRoutes6: [(String, UInt8, String?)] = [] // destination, prefix, gateway
             var optDNSServers: [String]?
+            var optDomain: String?
             var optSearchDomains: [String]?
             var optHTTPProxy: Proxy?
             var optHTTPSProxy: Proxy?
@@ -528,6 +531,17 @@ extension OpenVPN {
                     optDNSServers?.append($0[1])
                 }
                 Regex.domain.enumerateArguments(in: line) {
+                    guard $0.count == 2, optDomain == nil else {
+                        return
+                    }
+                    optDomain = $0[1]
+                    if optSearchDomains == nil {
+                        optSearchDomains = [optDomain!]
+                    } else {
+                        optSearchDomains?.insert(optDomain!, at: 0)
+                    }
+                }
+                Regex.domainSearch.enumerateArguments(in: line) {
                     guard $0.count == 2 else {
                         return
                     }


### PR DESCRIPTION
Non-breaking fix:

- Prioritize (single) DOMAIN entry in search domains
- Discard further DOMAIN options after the first one
- Recognize multiple DOMAIN-SEARCH options

Fixes #184 