### PR TITLE
Fix issue if sessionConfiguration.dnsServers is empty

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -718,7 +718,13 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
 
         // fall back
         if dnsSettings == nil {
-            dnsServers = cfg.sessionConfiguration.dnsServers ?? options.dnsServers ?? []
+            dnsServers = []
+            if let servers = cfg.sessionConfiguration.dnsServers,
+               !servers.isEmpty {
+                dnsServers = servers
+            } else if let servers = options.dnsServers {
+                dnsServers = servers
+            }
             if !dnsServers.isEmpty {
                 log.info("DNS: Using servers \(dnsServers.maskedDescription)")
                 dnsSettings = NEDNSSettings(servers: dnsServers)


### PR DESCRIPTION
While configuring the settings for the tunnel, if the value for `cfg.sessionConfiguration.dnsServers` is not null but it's an empty array, we are not setting the `dnsServers` object with the `options.dnsServers` value.