### PR TITLE
macOS: Enable accessing a password reference without system prompt

### DIFF
--- a/TunnelKit/Sources/AppExtension/Keychain.swift
+++ b/TunnelKit/Sources/AppExtension/Keychain.swift
@@ -320,6 +320,9 @@ public class Keychain {
     private func setScope(query: inout [String: Any], context: String?) {
         if let accessGroup = accessGroup {
             query[kSecAttrAccessGroup as String] = accessGroup
+            #if os(macOS)
+            query[kSecUseDataProtectionKeychain as String] = true
+            #endif
         }
         if let context = context {
             query[kSecAttrService as String] = context


### PR DESCRIPTION
In iOS, keychain sharing of password using access groups is enabled by default.

In macOS, it appears that we need to use the  `kSecUseDataProtectionKeychain` attribute to enable this behaviour. 

Current behaviour is that when the tunnel tries to access the tunnel password using the password reference, macOS shows a system prompt asking the user to authorize the access by typing in the user's system password. This PR enables accessing the tunnel password using the password reference without a system prompt.

As per the documentation on [Sharing Access to Keychain Items](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps):

> This form of keychain item sharing applies to all iOS keychain items, and to macOS keychain items when you query with the kSecUseDataProtectionKeychain key, set the item’s kSecAttrSynchronizable attribute, or both.
