### PR TITLE
Keychain: Use app group when dereferencing a password reference

### DIFF
--- a/TunnelKit/Sources/AppExtension/Keychain.swift
+++ b/TunnelKit/Sources/AppExtension/Keychain.swift
@@ -201,12 +201,10 @@ public class Keychain {
      - Returns: The password for the input username and reference.
      - Throws: `KeychainError.notFound` if unable to find the password in the keychain.
      **/
-    public static func password(for username: String, reference: Data, context: String? = nil) throws -> String {
+    public func password(for username: String, reference: Data, context: String? = nil) throws -> String {
         var query = [String: Any]()
+        setScope(query: &query, context: context)
         query[kSecClass as String] = kSecClassGenericPassword
-        if let context = context {
-            query[kSecAttrService as String] = context
-        }
         query[kSecAttrAccount as String] = username
         query[kSecMatchItemList as String] = [reference]
         query[kSecReturnData as String] = true

--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -212,9 +212,12 @@ open class OpenVPNTunnelProvider: NEPacketTunnelProvider {
 
         // optional credentials
         let credentials: OpenVPN.Credentials?
-        if let username = protocolConfiguration.username, let passwordReference = protocolConfiguration.passwordReference,
-            let password = try? Keychain.password(for: username, reference: passwordReference) {
-
+        if let username = protocolConfiguration.username, let passwordReference = protocolConfiguration.passwordReference {
+            let keychain = Keychain(group: appGroup)
+            guard let password = try? keychain.password(for: username, reference: passwordReference) else {
+                completionHandler(ProviderConfigurationError.credentials(details: "keychain.password(for:, reference:)"))
+                return
+            }
             credentials = OpenVPN.Credentials(username, password)
         } else {
             credentials = nil


### PR DESCRIPTION
Partially revert 4490f0c116d64d1c79f3ce2a1d2b0fe67549f640, where app group argument was erroneously omitted.

cc @roop