### PR TITLE
Cleanup cached PEMs at the end of a Session

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -243,11 +243,7 @@ public class OpenVPNSession: Session {
     /// :nodoc:
     deinit {
         cleanup()
-
-        let fm = FileManager.default
-        for url in [caURL, clientCertificateURL, clientKeyURL] {
-            try? fm.removeItem(at: url)
-        }
+        cleanupCache()
     }
     
     // MARK: Session
@@ -356,6 +352,13 @@ public class OpenVPNSession: Session {
         
         isStopping = false
         stopError = nil
+    }
+
+    func cleanupCache() {
+        let fm = FileManager.default
+        for url in [caURL, clientCertificateURL, clientKeyURL] {
+            try? fm.removeItem(at: url)
+        }
     }
 
     // MARK: Loop
@@ -1249,6 +1252,7 @@ public class OpenVPNSession: Session {
             switch method {
             case .shutdown:
                 self?.doShutdown(error: error)
+                self?.cleanupCache()
                 
             case .reconnect:
                 self?.doReconnect(error: error)


### PR DESCRIPTION
The CA key, the client certificate and client key are stored as PEMs on disk for invoking OpenSSL calls. These are called on deinit, but we do a hard exit on mac (`forceExitOnMac()`) so the deinit is never called. This PR removes the cached PEMs at the end of a session as well.

On a related note: Would it be better to not write these to disk at all, and make use of OpenSSL calls that work on in-memory keys/certificates?