### PR TITLE
Avoid caching PEMs on disk

### DIFF
--- a/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/AppExtension/OpenVPNTunnelProvider.swift
@@ -238,7 +238,7 @@ open class OpenVPNTunnelProvider: NEPacketTunnelProvider {
 
         let session: OpenVPNSession
         do {
-            session = try OpenVPNSession(queue: tunnelQueue, configuration: cfg.sessionConfiguration, cachesURL: cachesURL)
+            session = try OpenVPNSession(queue: tunnelQueue, configuration: cfg.sessionConfiguration)
             refreshDataCount()
         } catch let e {
             completionHandler(e)

--- a/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -765,6 +765,11 @@ public class OpenVPNSession: Session {
             return
         }
         
+        guard let ca = configuration.ca else {
+            log.error("Configuration doesn't have a CA")
+            return
+        }
+        
         // start new TLS handshake
         if ((packet.code == .hardResetServerV2) && (negotiationKey.state == .hardReset)) ||
             ((packet.code == .softResetV1) && (negotiationKey.state == .softReset)) {
@@ -788,9 +793,9 @@ public class OpenVPNSession: Session {
             log.debug("Start TLS handshake")
 
             let tls = TLSBox(
-                caPath: caURL.path,
-                clientCertificatePath: (configuration.clientCertificate != nil) ? clientCertificateURL.path : nil,
-                clientKeyPath: (configuration.clientKey != nil) ? clientKeyURL.path : nil,
+                ca: ca.pem,
+                clientCertificate: configuration.clientCertificate?.pem,
+                clientKey: configuration.clientKey?.pem,
                 checksEKU: configuration.checksEKU ?? false,
                 checksSANHost: configuration.checksSANHost ?? false,
                 hostname: configuration.sanHost

--- a/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
+++ b/TunnelKit/Sources/Protocols/OpenVPN/OpenVPNSession.swift
@@ -622,9 +622,13 @@ public class OpenVPNSession: Session {
     
     private func hardResetPayload() -> Data? {
         guard !(configuration.usesPIAPatches ?? false) else {
+            guard let ca = configuration.ca else {
+                log.error("Configuration doesn't have a CA")
+                return nil
+            }
             let caMD5: String
             do {
-                caMD5 = try TLSBox.md5(forCertificatePath: caURL.path)
+                caMD5 = try TLSBox.md5(forCertificatePEM: ca.pem)
             } catch {
                 log.error("CA MD5 could not be computed, skipping custom HARD_RESET")
                 return nil

--- a/TunnelKit/Sources/Protocols/OpenVPN/TLSBox.h
+++ b/TunnelKit/Sources/Protocols/OpenVPN/TLSBox.h
@@ -55,6 +55,7 @@ extern const NSInteger TLSBoxDefaultSecurityLevel;
 @property (nonatomic, assign) NSInteger securityLevel; // TLSBoxDefaultSecurityLevel for default
 
 + (nullable NSString *)md5ForCertificatePath:(NSString *)path error:(NSError **)error;
++ (nullable NSString *)md5ForCertificatePEM:(NSString *)pem error:(NSError **)error;
 + (nullable NSString *)decryptedPrivateKeyFromPath:(NSString *)path passphrase:(NSString *)passphrase error:(NSError **)error;
 + (nullable NSString *)decryptedPrivateKeyFromPEM:(NSString *)pem passphrase:(NSString *)passphrase error:(NSError **)error;
 

--- a/TunnelKit/Sources/Protocols/OpenVPN/TLSBox.h
+++ b/TunnelKit/Sources/Protocols/OpenVPN/TLSBox.h
@@ -58,12 +58,12 @@ extern const NSInteger TLSBoxDefaultSecurityLevel;
 + (nullable NSString *)decryptedPrivateKeyFromPath:(NSString *)path passphrase:(NSString *)passphrase error:(NSError **)error;
 + (nullable NSString *)decryptedPrivateKeyFromPEM:(NSString *)pem passphrase:(NSString *)passphrase error:(NSError **)error;
 
-- (instancetype)initWithCAPath:(NSString *)caPath
-         clientCertificatePath:(nullable NSString *)clientCertificatePath
-                 clientKeyPath:(nullable NSString *)clientKeyPath
-                     checksEKU:(BOOL)checksEKU
-                 checksSANHost:(BOOL)checksSANHost
-                      hostname:(nullable NSString *)hostname;
+- (instancetype)initWithCA:(nonnull NSString *)caPEM
+         clientCertificate:(nullable NSString *)clientCertificatePEM
+                 clientKey:(nullable NSString *)clientKeyPEM
+                 checksEKU:(BOOL)checksEKU
+             checksSANHost:(BOOL)checksSANHost
+                  hostname:(nullable NSString *)hostname;
 
 - (BOOL)startWithError:(NSError **)error;
 

--- a/TunnelKit/Sources/Protocols/OpenVPN/TLSBox.m
+++ b/TunnelKit/Sources/Protocols/OpenVPN/TLSBox.m
@@ -65,9 +65,9 @@ const NSInteger TLSBoxDefaultSecurityLevel = -1;
 
 @interface TLSBox ()
 
-@property (nonatomic, strong) NSString *caPath;
-@property (nonatomic, strong) NSString *clientCertificatePath;
-@property (nonatomic, strong) NSString *clientKeyPath;
+@property (nonatomic, strong) NSString *caPEM;
+@property (nonatomic, strong) NSString *clientCertificatePEM;
+@property (nonatomic, strong) NSString *clientKeyPEM;
 @property (nonatomic, assign) BOOL checksEKU;
 @property (nonatomic, assign) BOOL checksSANHost;
 @property (nonatomic, strong) NSString *hostname;
@@ -82,6 +82,10 @@ const NSInteger TLSBoxDefaultSecurityLevel = -1;
 @property (nonatomic, unsafe_unretained) uint8_t *bufferCipherText;
 
 @end
+
+static BIO *create_BIO_from_PEM(NSString *pem) {
+    return BIO_new_mem_buf([pem cStringUsingEncoding:NSASCIIStringEncoding], (int)[pem length]);
+}
 
 @implementation TLSBox
 
@@ -172,17 +176,17 @@ const NSInteger TLSBoxDefaultSecurityLevel = -1;
     return nil;
 }
 
-- (instancetype)initWithCAPath:(NSString *)caPath
-         clientCertificatePath:(NSString *)clientCertificatePath
-                 clientKeyPath:(NSString *)clientKeyPath
-                     checksEKU:(BOOL)checksEKU
-                 checksSANHost:(BOOL)checksSANHost
-                      hostname:(nullable NSString *)hostname
+- (instancetype)initWithCA:(nonnull NSString *)caPEM
+         clientCertificate:(nullable NSString *)clientCertificatePEM
+                 clientKey:(nullable NSString *)clientKeyPEM
+                 checksEKU:(BOOL)checksEKU
+             checksSANHost:(BOOL)checksSANHost
+                  hostname:(nullable NSString *)hostname
 {
     if ((self = [super init])) {
-        self.caPath = caPath;
-        self.clientCertificatePath = clientCertificatePath;
-        self.clientKeyPath = clientKeyPath;
+        self.caPEM = caPEM;
+        self.clientCertificatePEM = clientCertificatePEM;
+        self.clientKeyPEM = clientKeyPEM;
         self.checksEKU = checksEKU;
         self.checksSANHost = checksSANHost;
         self.bufferCipherText = allocate_safely(TLSBoxMaxBufferLength);
@@ -216,31 +220,47 @@ const NSInteger TLSBoxDefaultSecurityLevel = -1;
     if (self.securityLevel != TLSBoxDefaultSecurityLevel) {
         SSL_CTX_set_security_level(self.ctx, (int)self.securityLevel);
     }
-    if (!SSL_CTX_load_verify_locations(self.ctx, [self.caPath cStringUsingEncoding:NSASCIIStringEncoding], NULL)) {
-        ERR_print_errors_fp(stdout);
-        if (error) {
-            *error = TunnelKitErrorWithCode(TunnelKitErrorCodeTLSCertificateAuthority);
+
+    if (self.caPEM) {
+        BIO *bio = create_BIO_from_PEM(self.caPEM);
+        X509 *ca = PEM_read_bio_X509(bio, NULL, NULL, NULL);
+        BIO_free(bio);
+        X509_STORE *trustedStore = SSL_CTX_get_cert_store(self.ctx);
+        if (!X509_STORE_add_cert(trustedStore, ca)) {
+            ERR_print_errors_fp(stdout);
+            if (error) {
+                *error = TunnelKitErrorWithCode(TunnelKitErrorCodeTLSCertificateAuthority);
+            }
+            return NO;
         }
-        return NO;
     }
-    
-    if (self.clientCertificatePath) {
-        if (!SSL_CTX_use_certificate_file(self.ctx, [self.clientCertificatePath cStringUsingEncoding:NSASCIIStringEncoding], SSL_FILETYPE_PEM)) {
+
+    if (self.clientCertificatePEM) {
+        BIO *bio = create_BIO_from_PEM(self.clientCertificatePEM);
+        X509 *cert = PEM_read_bio_X509(bio, NULL, NULL, NULL);
+        BIO_free(bio);
+        if (!SSL_CTX_use_certificate(self.ctx, cert)) {
             ERR_print_errors_fp(stdout);
             if (error) {
                 *error = TunnelKitErrorWithCode(TunnelKitErrorCodeTLSClientCertificate);
             }
             return NO;
         }
+        X509_free(cert);
 
-        if (self.clientKeyPath) {
-            if (!SSL_CTX_use_PrivateKey_file(self.ctx, [self.clientKeyPath cStringUsingEncoding:NSASCIIStringEncoding], SSL_FILETYPE_PEM)) {
+        if (self.clientKeyPEM) {
+            BIO *bio = create_BIO_from_PEM(self.clientKeyPEM);
+            EVP_PKEY *pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+            BIO_free(bio);
+            if (!SSL_CTX_use_PrivateKey(self.ctx, pkey)) {
                 ERR_print_errors_fp(stdout);
                 if (error) {
                     *error = TunnelKitErrorWithCode(TunnelKitErrorCodeTLSClientKey);
                 }
                 return NO;
+
             }
+            EVP_PKEY_free(pkey);
         }
     }
 

--- a/TunnelKit/Tests/OpenVPN/EncryptionTests.swift
+++ b/TunnelKit/Tests/OpenVPN/EncryptionTests.swift
@@ -117,6 +117,11 @@ class EncryptionTests: XCTestCase {
         let exp = "e2fccccaba712ccc68449b1c56427ac1"
         print(md5)
         XCTAssertEqual(md5, exp)
+        
+        let pem = try! String(contentsOfFile: path, encoding: .ascii)
+        let md5FromPEM = try! TLSBox.md5(forCertificatePEM: pem)
+        print(md5FromPEM)
+        XCTAssertEqual(md5FromPEM, exp)
     }
     
     func testPrivateKeyDecryption() {


### PR DESCRIPTION
Previously, the CA key, the client certificate and client key were stored as PEMs on disk for invoking OpenSSL calls.

This PR uses the equivalent OpenSSL calls that operate on in-memory data, thereby avoiding writing these sensitive data to disk at all. (Previously discussed in PR #203.)