### PR TITLE
Verify CA from on-disk file

### DIFF
--- a/Sources/CTunnelKitOpenVPNProtocol/include/TLSBox.h
+++ b/Sources/CTunnelKitOpenVPNProtocol/include/TLSBox.h
@@ -55,16 +55,15 @@ extern const NSInteger TLSBoxDefaultSecurityLevel;
 @property (nonatomic, assign) NSInteger securityLevel; // TLSBoxDefaultSecurityLevel for default
 
 + (nullable NSString *)md5ForCertificatePath:(NSString *)path error:(NSError **)error;
-+ (nullable NSString *)md5ForCertificatePEM:(NSString *)pem error:(NSError **)error;
 + (nullable NSString *)decryptedPrivateKeyFromPath:(NSString *)path passphrase:(NSString *)passphrase error:(NSError **)error;
 + (nullable NSString *)decryptedPrivateKeyFromPEM:(NSString *)pem passphrase:(NSString *)passphrase error:(NSError **)error;
 
-- (instancetype)initWithCA:(nonnull NSString *)caPEM
-         clientCertificate:(nullable NSString *)clientCertificatePEM
-                 clientKey:(nullable NSString *)clientKeyPEM
-                 checksEKU:(BOOL)checksEKU
-             checksSANHost:(BOOL)checksSANHost
-                  hostname:(nullable NSString *)hostname;
+- (instancetype)initWithCAPath:(nonnull NSString *)caPath
+             clientCertificate:(nullable NSString *)clientCertificatePEM
+                     clientKey:(nullable NSString *)clientKeyPEM
+                     checksEKU:(BOOL)checksEKU
+                 checksSANHost:(BOOL)checksSANHost
+                      hostname:(nullable NSString *)hostname;
 
 - (BOOL)startWithError:(NSError **)error;
 

--- a/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
+++ b/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
@@ -241,7 +241,7 @@ open class OpenVPNTunnelProvider: NEPacketTunnelProvider {
 
         let session: OpenVPNSession
         do {
-            session = try OpenVPNSession(queue: tunnelQueue, configuration: cfg.sessionConfiguration)
+            session = try OpenVPNSession(queue: tunnelQueue, configuration: cfg.sessionConfiguration, cachesURL: cachesURL)
             refreshDataCount()
         } catch let e {
             completionHandler(e)

--- a/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
@@ -118,11 +118,6 @@ class EncryptionTests: XCTestCase {
         let exp = "e2fccccaba712ccc68449b1c56427ac1"
         print(md5)
         XCTAssertEqual(md5, exp)
-        
-        let pem = try! String(contentsOfFile: path, encoding: .ascii)
-        let md5FromPEM = try! TLSBox.md5(forCertificatePEM: pem)
-        print(md5FromPEM)
-        XCTAssertEqual(md5FromPEM, exp)
     }
     
     func testPrivateKeyDecryption() {


### PR DESCRIPTION
Revert part of #213 again, because `SSL_CTX_load_verify_locations`
is just more reliable at setting up the trust store.

It looks like it's able to reference the .pem multiple times in
those cases where the root issuer of the CA is also embedded in
the file (which is the case with e.g. Let's Encrypt).

This is better than the current implementation, and I couldn't
easily find a way to do the same in-memory. I'd rather use the
standard API here.

See 7a85d3cac7b7332983bae5aaf9e2878277d2450b

cc @roop 