### PR TITLE
Support --route-nopull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- OpenVPN: Support for `--route-nopull`.
+
 ### Changed
 
 - Upgrade OpenSSL to 1.1.1q.
+
+### Fixed
+
+- OpenVPN: Prioritize server configuration over client (standard behavior).
 
 ## 5.0.0 (2022-09-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- OpenVPN: Support for `--route-nopull`.
+- OpenVPN: Support for `--route-nopull`. [#280](https://github.com/passepartoutvpn/tunnelkit/pull/280)
 
 ### Changed
 

--- a/Sources/TunnelKitOpenVPNCore/ConfigurationParser.swift
+++ b/Sources/TunnelKitOpenVPNCore/ConfigurationParser.swift
@@ -119,6 +119,8 @@ extension OpenVPN {
             
             static let redirectGateway = NSRegularExpression("^redirect-gateway.*")
 
+            static let routeNoPull = NSRegularExpression("^route-nopull")
+
             // MARK: Unsupported
             
     //        static let fragment = NSRegularExpression("^fragment +\\d+")
@@ -291,6 +293,7 @@ extension OpenVPN {
             var optProxyAutoConfigurationURL: URL?
             var optProxyBypass: [String]?
             var optRedirectGateway: Set<RedirectGateway>?
+            var optRouteNoPull: Bool?
 
             log.verbose("Configuration file:")
             for line in lines {
@@ -702,6 +705,9 @@ extension OpenVPN {
                         optRedirectGateway?.insert(opt)
                     }
                 }
+                Regex.routeNoPull.enumerateComponents(in: line) { _ in
+                    optRouteNoPull = true
+                }
 
                 //
                 
@@ -888,6 +894,9 @@ extension OpenVPN {
             sessionBuilder.httpsProxy = optHTTPSProxy
             sessionBuilder.proxyAutoConfigurationURL = optProxyAutoConfigurationURL
             sessionBuilder.proxyBypassDomains = optProxyBypass
+            if optRouteNoPull ?? false {
+                sessionBuilder.noPullMask = [.routes, .dns, .proxy]
+            }
 
             if let flags = optRedirectGateway {
                 var policies: Set<RoutingPolicy> = []


### PR DESCRIPTION
With higher granularity than standard OpenVPN client, which instead rejects these settings altogether:

- Routes
- DNS
- Proxy

Also fixes incorrect priority of client settings over server-pulled settings. Server settings must always take over, unless `--route-nopull` is set.