### PR TITLE
Replace continuations with natively async methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade OpenSSL to 1.1.1q.
+- Use natively async methods from NetworkExtension. [#284](https://github.com/passepartoutvpn/tunnelkit/pull/284)
 
 ### Fixed
 


### PR DESCRIPTION
I used continuations unaware of ObjC providing implicit Concurrency counterparts to completion handlers.