### PR TITLE
Support --remote-random-hostname

### DIFF
--- a/Sources/TunnelKitOpenVPNAppExtension/ConnectionStrategy.swift
+++ b/Sources/TunnelKitOpenVPNAppExtension/ConnectionStrategy.swift
@@ -63,7 +63,10 @@ class ConnectionStrategy {
         if configuration.randomizeEndpoint ?? false {
             remotes.shuffle()
         }
-        self.remotes = remotes.map(ResolvedRemote.init)
+        let randomPrefixLength = (configuration.randomizeHostnames ?? false) ? OpenVPN.Configuration.randomHostnamePrefixLength : nil
+        self.remotes = remotes.map {
+            ResolvedRemote($0, randomPrefixLength: randomPrefixLength)
+        }
         currentRemoteIndex = 0
     }
 

--- a/Sources/TunnelKitOpenVPNAppExtension/ResolvedRemote.swift
+++ b/Sources/TunnelKitOpenVPNAppExtension/ResolvedRemote.swift
@@ -30,7 +30,7 @@ import SwiftyBeaver
 private let log = SwiftyBeaver.self
 
 class ResolvedRemote: CustomStringConvertible {
-    let originalEndpoint: Endpoint
+    private let originalEndpoint: Endpoint
     
     private(set) var isResolved: Bool
     
@@ -45,8 +45,17 @@ class ResolvedRemote: CustomStringConvertible {
         return resolvedEndpoints[currentEndpointIndex]
     }
     
-    init(_ originalEndpoint: Endpoint) {
-        self.originalEndpoint = originalEndpoint
+    init(_ originalEndpoint: Endpoint, randomPrefixLength: Int?) {
+        if let randomPrefixLength = randomPrefixLength {
+            do {
+                self.originalEndpoint = try originalEndpoint.withRandomPrefixLength(randomPrefixLength)
+            } catch {
+                log.warning("Could not prepend random prefix: \(error)")
+                self.originalEndpoint = originalEndpoint
+            }
+        } else {
+            self.originalEndpoint = originalEndpoint
+        }
         isResolved = false
         resolvedEndpoints = []
         currentEndpointIndex = 0

--- a/Sources/TunnelKitOpenVPNCore/Configuration.swift
+++ b/Sources/TunnelKitOpenVPNCore/Configuration.swift
@@ -229,6 +229,9 @@ extension OpenVPN {
         /// Picks endpoint from `remotes` randomly.
         public var randomizeEndpoint: Bool?
         
+        /// Prepend hostnames with a number of random bytes defined in `Configuration.randomHostnamePrefixLength`.
+        public var randomizeHostnames: Bool?
+        
         /// Server is patched for the PIA VPN provider.
         public var usesPIAPatches: Bool?
         
@@ -345,6 +348,7 @@ extension OpenVPN {
                 checksSANHost: checksSANHost,
                 sanHost: sanHost,
                 randomizeEndpoint: randomizeEndpoint,
+                randomizeHostnames: randomizeHostnames,
                 usesPIAPatches: usesPIAPatches,
                 mtu: mtu,
                 authUserPass: authUserPass,
@@ -380,6 +384,9 @@ extension OpenVPN {
             
             static let compressionAlgorithm: CompressionAlgorithm = .disabled
         }
+        
+        /// - Seealso: `ConfigurationBuilder.randomizeHostnames`
+        public static let randomHostnamePrefixLength = 6
         
         /// - Seealso: `ConfigurationBuilder.cipher`
         public let cipher: Cipher?
@@ -438,6 +445,9 @@ extension OpenVPN {
         /// - Seealso: `ConfigurationBuilder.randomizeEndpoint`
         public let randomizeEndpoint: Bool?
         
+        /// - Seealso: `ConfigurationBuilder.randomizeHostnames`
+        public var randomizeHostnames: Bool?
+
         /// - Seealso: `ConfigurationBuilder.usesPIAPatches`
         public let usesPIAPatches: Bool?
         
@@ -558,6 +568,7 @@ extension OpenVPN.Configuration {
         builder.checksSANHost = checksSANHost
         builder.sanHost = sanHost
         builder.randomizeEndpoint = randomizeEndpoint
+        builder.randomizeHostnames = randomizeHostnames
         builder.usesPIAPatches = usesPIAPatches
         builder.mtu = mtu
         builder.authUserPass = authUserPass
@@ -637,6 +648,9 @@ extension OpenVPN.Configuration {
         }
         if randomizeEndpoint ?? false {
             log.info("\tRandomize endpoint: true")
+        }
+        if randomizeHostnames ?? false {
+            log.info("\tRandomize hostnames: true")
         }
         if let routingPolicies = routingPolicies {
             log.info("\tGateway: \(routingPolicies.map { $0.rawValue })")

--- a/Sources/TunnelKitOpenVPNCore/ConfigurationParser.swift
+++ b/Sources/TunnelKitOpenVPNCore/ConfigurationParser.swift
@@ -85,6 +85,8 @@ extension OpenVPN {
             
             static let remoteRandom = NSRegularExpression("^remote-random")
             
+            static let remoteRandomHostname = NSRegularExpression("^remote-random-hostname")
+            
             static let mtu = NSRegularExpression("^tun-mtu +\\d+")
             
             // MARK: Server
@@ -123,7 +125,7 @@ extension OpenVPN {
 
             // MARK: Unsupported
             
-    //        static let fragment = NSRegularExpression("^fragment +\\d+")
+//            static let fragment = NSRegularExpression("^fragment +\\d+")
             static let fragment = NSRegularExpression("^fragment")
             
             static let connectionProxy = NSRegularExpression("^\\w+-proxy")
@@ -274,6 +276,7 @@ extension OpenVPN {
             var authUserPass = false
             var optChecksEKU: Bool?
             var optRandomizeEndpoint: Bool?
+            var optRandomizeHostnames: Bool?
             var optMTU: Int?
             //
             var optAuthToken: String?
@@ -574,6 +577,10 @@ extension OpenVPN {
                     isHandled = true
                     optRandomizeEndpoint = true
                 }
+                Regex.remoteRandomHostname.enumerateComponents(in: line) { _ in
+                    isHandled = true
+                    optRandomizeHostnames = true
+                }
                 Regex.mtu.enumerateArguments(in: line) {
                     isHandled = true
                     guard let str = $0.first else {
@@ -796,6 +803,7 @@ extension OpenVPN {
             sessionBuilder.authUserPass = authUserPass
             sessionBuilder.checksEKU = optChecksEKU
             sessionBuilder.randomizeEndpoint = optRandomizeEndpoint
+            sessionBuilder.randomizeHostnames = optRandomizeHostnames
             sessionBuilder.mtu = optMTU
             sessionBuilder.xorMask = optXorMask
             


### PR DESCRIPTION
Prepend a random 6-bytes string (12 hexes) to hostnames.

Reference: https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/