### PR TITLE
Unify logging of local/remote options

### DIFF
--- a/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
+++ b/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
@@ -487,40 +487,10 @@ extension OpenVPNTunnelProvider: OpenVPNSessionDelegate {
             log.info("\tProtocol: \(proto)")
         }
 
-        log.info("Returned ifconfig parameters:")
-        log.info("\tIPv4: \(options.ipv4?.description ?? "not configured")")
-        log.info("\tIPv6: \(options.ipv6?.description ?? "not configured")")
-        if let routingPolicies = options.routingPolicies {
-            log.info("\tGateway: \(routingPolicies.map { $0.rawValue })")
-        } else {
-            log.info("\tGateway: not configured")
-        }
-        if let dnsServers = options.dnsServers, !dnsServers.isEmpty {
-            log.info("\tDNS: \(dnsServers.map { $0.maskedDescription })")
-        } else {
-            log.info("\tDNS: not configured")
-        }
-        if let searchDomains = options.searchDomains, !searchDomains.isEmpty {
-            log.info("\tSearch domains: \(searchDomains.maskedDescription)")
-        } else {
-            log.info("\tSearch domains: not configured")
-        }
-
-        if options.httpProxy != nil || options.httpsProxy != nil || options.proxyAutoConfigurationURL != nil {
-            log.info("\tProxy:")
-            if let proxy = options.httpProxy {
-                log.info("\t\tHTTP: \(proxy.maskedDescription)")
-            }
-            if let proxy = options.httpsProxy {
-                log.info("\t\tHTTPS: \(proxy.maskedDescription)")
-            }
-            if let pacURL = options.proxyAutoConfigurationURL {
-                log.info("\t\tPAC: \(pacURL)")
-            }
-            if let bypass = options.proxyBypassDomains {
-                log.info("\t\tBypass domains: \(bypass.maskedDescription)")
-            }
-        }
+        log.info("Local options:")
+        cfg.configuration.print(isLocal: true)
+        log.info("Remote options:")
+        options.print(isLocal: false)
 
         cfg._appexSetServerConfiguration(session.serverConfiguration() as? OpenVPN.Configuration)
 

--- a/Sources/TunnelKitOpenVPNCore/Configuration.swift
+++ b/Sources/TunnelKitOpenVPNCore/Configuration.swift
@@ -617,92 +617,126 @@ extension OpenVPN.Configuration {
 // MARK: Encoding
 
 extension OpenVPN.Configuration {
-    public func print() {
-        guard let remotes = remotes else {
-            fatalError("No sessionConfiguration.remotes set")
+
+    // TODO: unmask things
+    public func print(isLocal: Bool) {
+        if isLocal {
+            guard let remotes = remotes else {
+                fatalError("No remotes set")
+            }
+            log.info("\tRemotes: \(remotes)")
         }
-        log.info("\tRemotes: \(remotes)")
-        log.info("\tCipher: \(fallbackCipher)")
-        log.info("\tDigest: \(fallbackDigest)")
-        log.info("\tCompression framing: \(fallbackCompressionFraming)")
-        log.info("\tCompression algorithm: \(fallbackCompressionAlgorithm)")
-        log.info("\tUsername authentication: \(authUserPass ?? false)")
-        if let _ = clientCertificate {
-            log.info("\tClient verification: enabled")
-        } else {
-            log.info("\tClient verification: disabled")
+
+        if !isLocal {
+            log.info("\tIPv4: \(ipv4?.description ?? "not configured")")
+            log.info("\tIPv6: \(ipv6?.description ?? "not configured")")
         }
-        if let tlsWrap = tlsWrap {
-            log.info("\tTLS wrapping: \(tlsWrap.strategy)")
-        } else {
-            log.info("\tTLS wrapping: disabled")
+
+        if let cipher = cipher {
+            log.info("\tCipher: \(cipher)")
+        } else if isLocal {
+            log.info("\tCipher: \(fallbackCipher)")
         }
-        if let tlsSecurityLevel = tlsSecurityLevel {
-            log.info("\tTLS security level: \(tlsSecurityLevel)")
-        } else {
-            log.info("\tTLS security level: default")
+        if let digest = digest {
+            log.info("\tDigest: \(digest)")
+        } else if isLocal {
+            log.info("\tDigest: \(fallbackDigest)")
         }
+        if let compressionFraming = compressionFraming {
+            log.info("\tCompression framing: \(compressionFraming)")
+        } else if isLocal {
+            log.info("\tCompression framing: \(fallbackCompressionFraming)")
+        }
+        if let compressionAlgorithm = compressionAlgorithm {
+            log.info("\tCompression algorithm: \(compressionAlgorithm)")
+        } else if isLocal {
+            log.info("\tCompression algorithm: \(fallbackCompressionAlgorithm)")
+        }
+
+        if isLocal {
+            log.info("\tUsername authentication: \(authUserPass ?? false)")
+            if let _ = clientCertificate {
+                log.info("\tClient verification: enabled")
+            } else {
+                log.info("\tClient verification: disabled")
+            }
+            if let tlsWrap = tlsWrap {
+                log.info("\tTLS wrapping: \(tlsWrap.strategy)")
+            } else {
+                log.info("\tTLS wrapping: disabled")
+            }
+            if let tlsSecurityLevel = tlsSecurityLevel {
+                log.info("\tTLS security level: \(tlsSecurityLevel)")
+            } else {
+                log.info("\tTLS security level: default")
+            }
+        }
+        
         if let keepAliveSeconds = keepAliveInterval, keepAliveSeconds > 0 {
             log.info("\tKeep-alive interval: \(keepAliveSeconds.asTimeString)")
-        } else {
+        } else if isLocal {
             log.info("\tKeep-alive interval: never")
         }
         if let keepAliveTimeoutSeconds = keepAliveTimeout, keepAliveTimeoutSeconds > 0 {
             log.info("\tKeep-alive timeout: \(keepAliveTimeoutSeconds.asTimeString)")
-        } else {
+        } else if isLocal {
             log.info("\tKeep-alive timeout: never")
         }
         if let renegotiatesAfterSeconds = renegotiatesAfter, renegotiatesAfterSeconds > 0 {
             log.info("\tRenegotiation: \(renegotiatesAfterSeconds.asTimeString)")
-        } else {
+        } else if isLocal {
             log.info("\tRenegotiation: never")
         }
         if checksEKU ?? false {
             log.info("\tServer EKU verification: enabled")
-        } else {
+        } else if isLocal {
             log.info("\tServer EKU verification: disabled")
         }
         if checksSANHost ?? false {
             log.info("\tHost SAN verification: enabled (\(sanHost ?? "-"))")
-        } else {
+        } else if isLocal {
             log.info("\tHost SAN verification: disabled")
         }
+
         if randomizeEndpoint ?? false {
             log.info("\tRandomize endpoint: true")
         }
         if randomizeHostnames ?? false {
             log.info("\tRandomize hostnames: true")
         }
+
         if let routingPolicies = routingPolicies {
             log.info("\tGateway: \(routingPolicies.map(\.rawValue))")
-        } else {
+        } else if isLocal {
             log.info("\tGateway: not configured")
         }
+
         switch dnsProtocol {
         case .https:
             if let dnsHTTPSURL = dnsHTTPSURL {
                 log.info("\tDNS over HTTPS: \(dnsHTTPSURL.maskedDescription)")
-            } else {
+            } else if isLocal {
                 log.info("\tDNS: not configured")
             }
 
         case .tls:
             if let dnsTLSServerName = dnsTLSServerName {
                 log.info("\tDNS over TLS: \(dnsTLSServerName.maskedDescription)")
-            } else {
+            } else if isLocal {
                 log.info("\tDNS: not configured")
             }
 
         default:
             if let dnsServers = dnsServers, !dnsServers.isEmpty {
                 log.info("\tDNS: \(dnsServers.maskedDescription)")
-            } else {
+            } else if isLocal {
                 log.info("\tDNS: not configured")
             }
         }
         if let searchDomains = searchDomains, !searchDomains.isEmpty {
             log.info("\tSearch domains: \(searchDomains.maskedDescription)")
         }
+
         if let httpProxy = httpProxy {
             log.info("\tHTTP proxy: \(httpProxy.maskedDescription)")
         }
@@ -715,12 +749,14 @@ extension OpenVPN.Configuration {
         if let proxyBypassDomains = proxyBypassDomains {
             log.info("\tProxy bypass domains: \(proxyBypassDomains.maskedDescription)")
         }
+
         if let mtu = mtu {
             log.info("\tMTU: \(mtu)")
-        } else {
+        } else if isLocal {
             log.info("\tMTU: default")
         }
-        if let noPullMask = noPullMask {
+
+        if isLocal, let noPullMask = noPullMask {
             log.info("\tNot pulled: \(noPullMask.map(\.rawValue))")
         }
     }

--- a/Sources/TunnelKitOpenVPNManager/OpenVPN+ProviderConfiguration.swift
+++ b/Sources/TunnelKitOpenVPNManager/OpenVPN+ProviderConfiguration.swift
@@ -74,7 +74,7 @@ extension OpenVPN {
         /// Mask private data in debug log (default is `true`).
         public var masksPrivateData = true
         
-                public init(_ title: String, appGroup: String, configuration: OpenVPN.Configuration) {
+        public init(_ title: String, appGroup: String, configuration: OpenVPN.Configuration) {
             self.title = title
             self.appGroup = appGroup
             self.configuration = configuration
@@ -84,9 +84,9 @@ extension OpenVPN {
             if let versionIdentifier = versionIdentifier {
                 log.info("Tunnel version: \(versionIdentifier)")
             }
-            configuration.print()
             log.info("Debug: \(shouldDebug)")
             log.info("Masks private data: \(masksPrivateData)")
+            configuration.print(isLocal: true)
         }
     }
 }


### PR DESCRIPTION
Refine print() method to print both local and remote options when a connection starts.