### PR TITLE
Set includeAllNetworks for best-effort kill switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - OpenVPN: Support for `--route-nopull`. [#280](https://github.com/passepartoutvpn/tunnelkit/pull/280)
 - OpenVPN: Support for `--remote-random-hostname`. [#286](https://github.com/passepartoutvpn/tunnelkit/pull/286)
+- Use .includeAllNetworks for best-effort kill switch. [#300](https://github.com/passepartoutvpn/tunnelkit/pull/300)
 
 ### Changed
 

--- a/Sources/TunnelKitOpenVPNManager/OpenVPN+ProviderConfiguration.swift
+++ b/Sources/TunnelKitOpenVPNManager/OpenVPN+ProviderConfiguration.swift
@@ -59,6 +59,9 @@ extension OpenVPN {
         /// The client configuration.
         public let configuration: OpenVPN.Configuration
         
+        /// Enables kill switch.
+        public var killSwitch: Bool?
+
         /// The optional username.
         public var username: String?
         
@@ -112,8 +115,8 @@ extension OpenVPN.ProviderConfiguration: NetworkExtensionConfiguration {
         }
         protocolConfiguration.disconnectOnSleep = extra?.disconnectsOnSleep ?? false
         protocolConfiguration.providerConfiguration = try asDictionary()
-        if #available(iOS 14, *) {
-            protocolConfiguration.includeAllNetworks = true
+        if #available(iOS 14, *), let killSwitch = killSwitch {
+            protocolConfiguration.includeAllNetworks = killSwitch
         }
         return protocolConfiguration
     }

--- a/Sources/TunnelKitOpenVPNManager/OpenVPN+ProviderConfiguration.swift
+++ b/Sources/TunnelKitOpenVPNManager/OpenVPN+ProviderConfiguration.swift
@@ -95,7 +95,7 @@ extension OpenVPN {
 
 extension OpenVPN.ProviderConfiguration: NetworkExtensionConfiguration {
 
-        public func asTunnelProtocol(
+    public func asTunnelProtocol(
         withBundleIdentifier tunnelBundleIdentifier: String,
         extra: NetworkExtensionExtra?
     ) throws -> NETunnelProviderProtocol {
@@ -112,6 +112,9 @@ extension OpenVPN.ProviderConfiguration: NetworkExtensionConfiguration {
         }
         protocolConfiguration.disconnectOnSleep = extra?.disconnectsOnSleep ?? false
         protocolConfiguration.providerConfiguration = try asDictionary()
+        if #available(iOS 14, *) {
+            protocolConfiguration.includeAllNetworks = true
+        }
         return protocolConfiguration
     }
 }

--- a/Sources/TunnelKitWireGuardManager/WireGuard+ProviderConfiguration.swift
+++ b/Sources/TunnelKitWireGuardManager/WireGuard+ProviderConfiguration.swift
@@ -49,6 +49,8 @@ extension WireGuard {
 
         public let configuration: WireGuard.Configuration
 
+        public var killSwitch: Bool?
+
         public var shouldDebug = false
 
         public var debugLogPath: String? = nil
@@ -83,8 +85,8 @@ extension WireGuard.ProviderConfiguration: NetworkExtensionConfiguration {
         protocolConfiguration.passwordReference = extra?.passwordReference
         protocolConfiguration.disconnectOnSleep = extra?.disconnectsOnSleep ?? false
         protocolConfiguration.providerConfiguration = try asDictionary()
-        if #available(iOS 14, *) {
-            protocolConfiguration.includeAllNetworks = true
+        if #available(iOS 14, *), let killSwitch = killSwitch {
+            protocolConfiguration.includeAllNetworks = killSwitch
         }
         return protocolConfiguration
     }

--- a/Sources/TunnelKitWireGuardManager/WireGuard+ProviderConfiguration.swift
+++ b/Sources/TunnelKitWireGuardManager/WireGuard+ProviderConfiguration.swift
@@ -73,7 +73,7 @@ extension WireGuard {
 
 extension WireGuard.ProviderConfiguration: NetworkExtensionConfiguration {
 
-        public func asTunnelProtocol(
+    public func asTunnelProtocol(
         withBundleIdentifier tunnelBundleIdentifier: String,
         extra: NetworkExtensionExtra?
     ) throws -> NETunnelProviderProtocol {
@@ -83,6 +83,9 @@ extension WireGuard.ProviderConfiguration: NetworkExtensionConfiguration {
         protocolConfiguration.passwordReference = extra?.passwordReference
         protocolConfiguration.disconnectOnSleep = extra?.disconnectsOnSleep ?? false
         protocolConfiguration.providerConfiguration = try asDictionary()
+        if #available(iOS 14, *) {
+            protocolConfiguration.includeAllNetworks = true
+        }
         return protocolConfiguration
     }
 }


### PR DESCRIPTION
According to Apple, this is the best that can be done to accomplish kill switch behavior:

- https://developer.apple.com/documentation/networkextension/nevpnprotocol/3131931-includeallnetworks
- https://9to5mac.com/2022/08/19/iphone-vpn-app-security-debate-continues-as-apple-says-its-fixed-and-protonvpn-says-not/