### PR TITLE
Reuse native WireGuard error as ConfigurationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- WireGuard: Return native parsing errors from WireGuardKit. [#316](https://github.com/passepartoutvpn/tunnelkit/pull/316)
+
 ## 6.0.0 (2023-04-01)
 
 ### Added

--- a/Sources/TunnelKitWireGuardCore/Configuration+WireGuardKit.swift
+++ b/Sources/TunnelKitWireGuardCore/Configuration+WireGuardKit.swift
@@ -26,17 +26,9 @@
 import Foundation
 import WireGuardKit
 
-public struct ConfigurationError: Error {
-    let parseError: TunnelConfiguration.ParseError
-}
-
 extension WireGuard.Configuration {
     public init(wgQuickConfig: String) throws {
-        do {
-            tunnelConfiguration = try TunnelConfiguration(fromWgQuickConfig: wgQuickConfig)
-        } catch let parseError as TunnelConfiguration.ParseError {
-            throw ConfigurationError(parseError: parseError)
-        }
+        tunnelConfiguration = try TunnelConfiguration(fromWgQuickConfig: wgQuickConfig)
     }
 
     public func asWgQuickConfig() -> String {

--- a/Sources/TunnelKitWireGuardCore/Configuration.swift
+++ b/Sources/TunnelKitWireGuardCore/Configuration.swift
@@ -77,7 +77,7 @@ extension WireGuard {
 
         public init(_ base64PrivateKey: String) throws {
             guard let privateKey = PrivateKey(base64Key: base64PrivateKey) else {
-                throw WireGuard.ConfigurationError.invalidKey
+                throw WireGuard.ConfigurationError.interfaceHasInvalidPrivateKey(base64PrivateKey)
             }
             self.init(privateKey)
         }
@@ -164,7 +164,7 @@ extension WireGuard {
 
         public mutating func addPeer(_ base64PublicKey: String, endpoint: String, allowedIPs: [String] = []) throws {
             guard let publicKey = PublicKey(base64Key: base64PublicKey) else {
-                throw WireGuard.ConfigurationError.invalidKey
+                throw WireGuard.ConfigurationError.peerHasInvalidPublicKey(base64PublicKey)
             }
             var peer = PeerConfiguration(publicKey: publicKey)
             peer.endpoint = Endpoint(from: endpoint)
@@ -174,7 +174,7 @@ extension WireGuard {
 
         public mutating func setPreSharedKey(_ base64Key: String, ofPeer peerIndex: Int) throws {
             guard let preSharedKey = PreSharedKey(base64Key: base64Key) else {
-                throw WireGuard.ConfigurationError.invalidKey
+                throw WireGuard.ConfigurationError.peerHasInvalidPreSharedKey(base64Key)
             }
             peers[peerIndex].preSharedKey = preSharedKey
         }

--- a/Sources/TunnelKitWireGuardCore/ConfigurationError.swift
+++ b/Sources/TunnelKitWireGuardCore/ConfigurationError.swift
@@ -24,9 +24,8 @@
 //
 
 import Foundation
+import WireGuardKit
 
 extension WireGuard {
-    public enum ConfigurationError: Error {
-        case invalidKey
-    }
+    public typealias ConfigurationError = TunnelConfiguration.ParseError
 }

--- a/Sources/TunnelKitWireGuardCore/Internal/TunnelConfiguration+WgQuickConfig.swift
+++ b/Sources/TunnelKitWireGuardCore/Internal/TunnelConfiguration+WgQuickConfig.swift
@@ -13,7 +13,7 @@ extension TunnelConfiguration {
         case notInASection
     }
 
-    enum ParseError: Error {
+    public enum ParseError: Error {
         case invalidLine(String.SubSequence)
         case noInterface
         case multipleInterfaces


### PR DESCRIPTION
There was a duplicate ConfigurationError.