### PR TITLE
Fix keychain error escaping catch block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Keychain may fail to set password. [#327](https://github.com/passepartoutvpn/tunnelkit/issues/327)
+
 ## 6.1.0 (2023-07-05)
 
 ### Changed

--- a/Sources/TunnelKitManager/Keychain.swift
+++ b/Sources/TunnelKitManager/Keychain.swift
@@ -82,7 +82,7 @@ public class Keychain {
      - Parameter userDefined: Optional user-defined data.
      - Parameter label: An optional label.
      - Returns: The reference to the password.
-     - Throws: `KeychainError.add` if unable to add the password to the keychain.
+     - Throws: `TunnelKitManagerError.keychain` if unable to add the password to the keychain.
      **/
     @discardableResult
     public func set(password: String, for username: String, context: String, userDefined: String? = nil, label: String? = nil) throws -> Data {
@@ -92,10 +92,10 @@ public class Keychain {
                 return try passwordReference(for: username, context: context)
             }
             removePassword(for: username, context: context)
-        } catch let error as KeychainError {
+        } catch let error as TunnelKitManagerError {
 
             // rethrow cancelation
-            if error == .userCancelled {
+            if case .keychain(.userCancelled) = error {
                 throw error
             }
 
@@ -144,7 +144,7 @@ public class Keychain {
      - Parameter context: The context.
      - Parameter userDefined: Optional user-defined data.
      - Returns: The password for the input username.
-     - Throws: `KeychainError.notFound` if unable to find the password in the keychain.
+     - Throws: `TunnelKitManagerError.keychain` if unable to find the password in the keychain.
      **/
     public func password(for username: String, context: String, userDefined: String? = nil) throws -> String {
         var query = [String: Any]()
@@ -181,7 +181,7 @@ public class Keychain {
      - Parameter context: The context.
      - Parameter userDefined: Optional user-defined data.
      - Returns: The password reference for the input username.
-     - Throws: `KeychainError.notFound` if unable to find the password in the keychain.
+     - Throws: `TunnelKitManagerError.keychain` if unable to find the password in the keychain.
      **/
     public func passwordReference(for username: String, context: String, userDefined: String? = nil) throws -> Data {
         var query = [String: Any]()
@@ -213,7 +213,7 @@ public class Keychain {
 
      - Parameter reference: The password reference.
      - Returns: The password for the input reference.
-     - Throws: `KeychainError.notFound` if unable to find the password in the keychain.
+     - Throws: `TunnelKitManagerError.keychain` if unable to find the password in the keychain.
      **/
     public static func password(forReference reference: Data) throws -> String {
         var query = [String: Any]()
@@ -250,7 +250,7 @@ public class Keychain {
      - Parameter identifier: The unique identifier.
      - Parameter data: The public key data.
      - Returns: The `SecKey` object representing the public key.
-     - Throws: `KeychainError.add` if unable to add the public key to the keychain.
+     - Throws: `TunnelKitManagerError.keychain` if unable to add the public key to the keychain.
      **/
     public func add(publicKeyWithIdentifier identifier: String, data: Data) throws -> SecKey {
         var query = [String: Any]()
@@ -275,7 +275,7 @@ public class Keychain {
 
      - Parameter identifier: The unique identifier.
      - Returns: The `SecKey` object representing the public key.
-     - Throws: `KeychainError.notFound` if unable to find the public key in the keychain.
+     - Throws: `TunnelKitManagerError.keychain` if unable to find the public key in the keychain.
      **/
     public func publicKey(withIdentifier identifier: String) throws -> SecKey {
         var query = [String: Any]()

--- a/Sources/TunnelKitManager/Keychain.swift
+++ b/Sources/TunnelKitManager/Keychain.swift
@@ -94,12 +94,18 @@ public class Keychain {
             removePassword(for: username, context: context)
         } catch let error as TunnelKitManagerError {
 
-            // rethrow cancelation
+            // this is a well-known error from password() or passwordReference(), keep going
+
+            // rethrow cancellation
             if case .keychain(.userCancelled) = error {
                 throw error
             }
 
             // otherwise, no pre-existing password
+        } catch {
+
+            // IMPORTANT: rethrow any other unknown error (leave this code explicit)
+            throw error
         }
 
         var query = [String: Any]()


### PR DESCRIPTION
When setting a keychain password, there is a specific catch block for KeychainError. That is, when looking for an existing password, we want to keep going when well-known errors (KeychainError) are thrown, and rethrow any other error.

However, in #325, Keychain.password() throws instances of TunnelKitManagerError, thus escaping the KeychainError catch block. The nasty effect of this is that if we fail to find an existing password, the method may rethrow immediately and fail to set a password.

Bottom line: Swift untyped error handling sucks.

Fixes #327