### PR TITLE
Convert encryption tests to proper unit tests

### DIFF
--- a/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
+++ b/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
@@ -151,13 +151,15 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
     int code = 1;
 
     if (self.cipher) {
-        if (RAND_bytes(outIV, self.cipherIVLength) != 1) {
-            if (error) {
-                *error = OpenVPNErrorWithCode(OpenVPNErrorCodeCryptoRandomGenerator);
+        if (!flags || !flags->forTesting) {
+            if (RAND_bytes(outIV, self.cipherIVLength) != 1) {
+                if (error) {
+                    *error = OpenVPNErrorWithCode(OpenVPNErrorCodeCryptoRandomGenerator);
+                }
+                return NO;
             }
-            return NO;
         }
-        
+
         TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherInit(self.cipherCtxEnc, NULL, NULL, outIV, -1);
         TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherUpdate(self.cipherCtxEnc, outEncrypted, &l1, bytes, (int)length);
         TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherFinal_ex(self.cipherCtxEnc, outEncrypted + l1, &l2);

--- a/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
+++ b/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
@@ -205,8 +205,6 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
 
 - (BOOL)decryptBytes:(const uint8_t *)bytes length:(NSInteger)length dest:(uint8_t *)dest destLength:(NSInteger *)destLength flags:(const CryptoFlags * _Nullable)flags error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
-    NSAssert(self.cipher, @"No cipher provided");
-
     const uint8_t *iv = bytes + self.digestLength;
     const uint8_t *encrypted = bytes + self.digestLength + self.cipherIVLength;
     int l1 = 0, l2 = 0;
@@ -223,11 +221,18 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
         return NO;
     }
     
-    TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherInit(self.cipherCtxDec, NULL, NULL, iv, -1);
-    TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherUpdate(self.cipherCtxDec, dest, &l1, encrypted, (int)length - self.digestLength - self.cipherIVLength);
-    TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherFinal_ex(self.cipherCtxDec, dest + l1, &l2);
+    if (self.cipher) {
+        TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherInit(self.cipherCtxDec, NULL, NULL, iv, -1);
+        TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherUpdate(self.cipherCtxDec, dest, &l1, encrypted, (int)length - self.digestLength - self.cipherIVLength);
+        TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_CipherFinal_ex(self.cipherCtxDec, dest + l1, &l2);
 
-    *destLength = l1 + l2;
+        *destLength = l1 + l2;
+    } else {
+        l2 = (int)length - l1;
+        memcpy(dest, bytes + l1, l2);
+
+        *destLength = l2;
+    }
 
     TUNNEL_CRYPTO_RETURN_STATUS(code)
 }

--- a/Sources/CTunnelKitOpenVPNProtocol/include/Crypto.h
+++ b/Sources/CTunnelKitOpenVPNProtocol/include/Crypto.h
@@ -47,6 +47,7 @@ typedef struct {
     NSInteger ivLength;
     const uint8_t *_Nullable ad;
     NSInteger adLength;
+    BOOL forTesting;
 } CryptoFlags;
 
 // WARNING: dest must be able to hold ciphertext

--- a/Sources/TunnelKitOpenVPNProtocol/ControlChannelSerializer.swift
+++ b/Sources/TunnelKitOpenVPNProtocol/ControlChannelSerializer.swift
@@ -282,7 +282,7 @@ extension OpenVPN.ControlChannel {
             var decryptedCount = 0
             try packet.withUnsafeBytes {
                 let src = $0.bytePointer
-                var flags = CryptoFlags(iv: nil, ivLength: 0, ad: src, adLength: adLength)
+                var flags = CryptoFlags(iv: nil, ivLength: 0, ad: src, adLength: adLength, forTesting: false)
                 try decryptedPacket.withUnsafeMutableBytes {
                     let dest = $0.bytePointer
                     try decrypter.decryptBytes(src + flags.adLength, length: encryptedCount, dest: dest + headerLength, destLength: &decryptedCount, flags: &flags)

--- a/Tests/TunnelKitCoreTests/RandomTests.swift
+++ b/Tests/TunnelKitCoreTests/RandomTests.swift
@@ -48,15 +48,8 @@ class RandomTests: XCTestCase {
     }
 
     func testRandom1() {
-        print(try! SecureRandom.uint32())
-        print(try! SecureRandom.uint32())
-        print(try! SecureRandom.uint32())
-        print(try! SecureRandom.uint32())
-        print(try! SecureRandom.uint32())
     }
 
     func testRandom2() {
-        print("random UInt32: \(try! SecureRandom.uint32())")
-        print("random bytes: \(try! SecureRandom.data(length: 12).toHex())")
     }
 }

--- a/Tests/TunnelKitCoreTests/RoutingTests.swift
+++ b/Tests/TunnelKitCoreTests/RoutingTests.swift
@@ -38,7 +38,6 @@ class RoutingTests: XCTestCase {
 
     func testEntryMatch4() {
         let entry24 = RoutingTableEntry(iPv4Network: "192.168.1.0/24", gateway: nil, networkInterface: "en0")
-        print(entry24.networkMask()!)
         for i in 0x0...0xff {
             XCTAssertTrue(entry24.matchesDestination("192.168.1.\(i)"))
         }
@@ -47,7 +46,6 @@ class RoutingTests: XCTestCase {
         }
 
         let entry28 = RoutingTableEntry(iPv4Network: "192.168.1.0/28", gateway: nil, networkInterface: "en0")
-        print(entry28.networkMask()!)
         for i in 0x0...0xf {
             XCTAssertTrue(entry28.matchesDestination("192.168.1.\(i)"))
         }
@@ -70,13 +68,10 @@ class RoutingTests: XCTestCase {
         let table = RoutingTable()
 
         for entry in table.ipv4() {
-            print(entry)
         }
 
         if let defaultGateway = table.defaultGateway4()?.gateway() {
-            print("Default gateway: \(defaultGateway)")
             if let lan = table.broadestRoute4(matchingDestination: defaultGateway) {
-                print("Gateway LAN: \(lan.network())/\(lan.prefix())")
             }
         }
     }
@@ -85,13 +80,10 @@ class RoutingTests: XCTestCase {
         let table = RoutingTable()
 
         for entry in table.ipv6() {
-            print(entry)
         }
 
         if let defaultGateway = table.defaultGateway6()?.gateway() {
-            print("Default gateway: \(defaultGateway)")
             if let lan = table.broadestRoute6(matchingDestination: defaultGateway) {
-                print("Gateway LAN: \(lan.network())/\(lan.prefix())")
             }
         }
     }

--- a/Tests/TunnelKitLZOTests/CompressionTests.swift
+++ b/Tests/TunnelKitLZOTests/CompressionTests.swift
@@ -32,7 +32,6 @@ class CompressionTests: XCTestCase {
 
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
-//        print("LZO version: \(LZO.versionString())")
     }
 
     override func tearDown() {
@@ -51,8 +50,6 @@ class CompressionTests: XCTestCase {
             XCTFail("Unable to decompress data")
             return
         }
-        print("BEFORE: \(src)")
-        print("AFTER : \(dstDecompressed)")
         XCTAssertEqual(src, dstDecompressed)
     }
 }

--- a/Tests/TunnelKitOpenVPNTests/AppExtensionTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/AppExtensionTests.swift
@@ -88,7 +88,6 @@ class AppExtensionTests: XCTestCase {
         guard let pc = proto.providerConfiguration else {
             return
         }
-        print("\(pc)")
 
         let ovpn = pc["configuration"] as? [String: Any]
         XCTAssertEqual(pc["appGroup"] as? String, appGroup)
@@ -107,11 +106,11 @@ class AppExtensionTests: XCTestCase {
                 exp.fulfill()
             }
             switch $0 {
-            case .success(let records):
-                print("\(records)")
+            case .success:
+                break
 
             case .failure:
-                print("Can't resolve")
+                break
             }
         }
         waitForExpectations(timeout: 5.0, handler: nil)
@@ -159,7 +158,6 @@ class AppExtensionTests: XCTestCase {
             guard let remote = strategy.currentRemote else {
                 break
             }
-            print("\(i): \(remote)")
             XCTAssertEqual(remote.originalEndpoint.description, expected[i])
             i += 1
             guard strategy.tryNextEndpoint() else {
@@ -190,7 +188,6 @@ class AppExtensionTests: XCTestCase {
 //        var i = 0
 //        while strategy.hasEndpoint() {
 //            let endpoint = strategy.currentEndpoint()
-//            print("\(endpoint)")
 //            XCTAssertEqual(endpoint.description, expected[i])
 //            i += 1
 //            strategy.tryNextEndpoint()
@@ -219,7 +216,6 @@ class AppExtensionTests: XCTestCase {
 //        var i = 0
 //        while strategy.hasEndpoint() {
 //            let endpoint = strategy.currentEndpoint()
-//            print("\(endpoint)")
 //            XCTAssertEqual(endpoint.description, expected[i])
 //            i += 1
 //            strategy.tryNextEndpoint()

--- a/Tests/TunnelKitOpenVPNTests/ConfigurationParserTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/ConfigurationParserTests.swift
@@ -118,8 +118,7 @@ class ConfigurationParserTests: XCTestCase {
 
     func testStripped() throws {
         let lines = try OpenVPN.ConfigurationParser.parsed(fromURL: url(withName: "pia-hungary"), returnsStripped: true).strippedLines!
-        let stripped = lines.joined(separator: "\n")
-        print(stripped)
+        _ = lines.joined(separator: "\n")
     }
 
     func testEncryptedCertificateKey() throws {

--- a/Tests/TunnelKitOpenVPNTests/ControlChannelTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/ControlChannelTests.swift
@@ -60,7 +60,6 @@ class ControlChannelTests: XCTestCase {
         let hmac = Data(hex: "e67c9137933a412a711c0d0514aca6db6476d17d")
         let subject = Data(hex: "000000015b96c94738858fe14742fdae400000000000")
         let data = hmac + subject
-        print(data.toHex())
 
         XCTAssertNoThrow(try server.decrypter().verifyData(data, flags: nil))
     }
@@ -98,8 +97,6 @@ class ControlChannelTests: XCTestCase {
             XCTAssertNil(error)
             return
         }
-        print("raw: \(raw.toHex())")
-        print("org: \(original.toHex())")
         XCTAssertEqual(raw, original)
     }
 
@@ -130,8 +127,6 @@ class ControlChannelTests: XCTestCase {
             XCTAssertNil(error)
             return
         }
-        print("raw: \(raw.toHex())")
-        print("org: \(original.toHex())")
         XCTAssertEqual(raw, original)
     }
 }

--- a/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
@@ -30,37 +30,31 @@ import CTunnelKitCore
 import CTunnelKitOpenVPNProtocol
 
 class CryptoAEADTests: XCTestCase {
-    private let cipherKey = ZeroingData(string: "aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff", nullTerminated: false)
+    private let cipherKey = ZeroingData(count: 32)
 
-    private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
+    private let hmacKey = ZeroingData(count: 32)
 
     private let plainData = Data(hex: "00112233ffddaa")
 
-    private let encryptedData = Data(hex: "924e38066ef07f36e621a4b12322f68b4620ff9fad0c33")
-
-    func test_givenDecrypted_whenEncrypt_thenEncrypts() {
+    func test_givenData_whenEncrypt_thenDecrypts() {
         let sut = CryptoAEAD(cipherName: "aes-256-gcm")
         sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
-
-        var flags = cryptoFlags
-        do {
-            let returnedData = try sut.encryptData(plainData, flags: &flags)
-            XCTAssertEqual(returnedData, encryptedData)
-        } catch {
-            XCTFail("Cannot encrypt: \(error)")
-        }
-    }
-
-    func test_givenEncrypted_whenDecrypt_thenDecrypts() {
-        let sut = CryptoAEAD(cipherName: "aes-256-gcm")
         sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
 
         var flags = cryptoFlags
+        let encryptedData: Data
+        do {
+            encryptedData = try sut.encryptData(plainData, flags: &flags)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+            return
+        }
         do {
             let returnedData = try sut.decryptData(encryptedData, flags: &flags)
             XCTAssertEqual(returnedData, plainData)
         } catch {
             XCTFail("Cannot decrypt: \(error)")
+            return
         }
     }
 

--- a/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
@@ -1,0 +1,65 @@
+//
+//  CryptoAEADTests.swift
+//  TunnelKitOpenVPNTests
+//
+//  Created by Davide De Rosa on 12/12/23.
+//  Copyright (c) 2023 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of TunnelKit.
+//
+//  TunnelKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  TunnelKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with TunnelKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import TunnelKitCore
+@testable import TunnelKitOpenVPNCore
+import CTunnelKitCore
+import CTunnelKitOpenVPNProtocol
+
+class CryptoAEADTests: XCTestCase {
+    private let cipherKey = ZeroingData(string: "aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff", nullTerminated: false)
+
+    private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
+
+    func test_whenEncrypt_thenResultMatches() {
+        let sut = CryptoAEAD(cipherName: "aes-256-gcm")
+        sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+
+        let data = Data(hex: "00112233ffddaa")
+        var flags = cryptoFlags
+        let expectedData = Data(hex: "924e38066ef07f36e621a4b12322f68b4620ff9fad0c33")
+        do {
+            let returnedData = try sut.encryptData(data, flags: &flags)
+            XCTAssertEqual(returnedData, expectedData)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+        }
+    }
+
+    private var cryptoFlags: CryptoFlags {
+        let packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
+        let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
+        return packetId.withUnsafeBufferPointer { (iv) in
+            ad.withUnsafeBufferPointer { (ad) in
+                return CryptoFlags(iv: iv.baseAddress,
+                                   ivLength: packetId.count,
+                                   ad: ad.baseAddress,
+                                   adLength: ad.count,
+                                   forTesting: true)
+            }
+        }
+    }
+}

--- a/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
@@ -34,18 +34,33 @@ class CryptoAEADTests: XCTestCase {
 
     private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
 
-    func test_whenEncrypt_thenResultMatches() {
+    private let plainData = Data(hex: "00112233ffddaa")
+
+    private let encryptedData = Data(hex: "924e38066ef07f36e621a4b12322f68b4620ff9fad0c33")
+
+    func test_givenDecrypted_whenEncrypt_thenEncrypts() {
         let sut = CryptoAEAD(cipherName: "aes-256-gcm")
         sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
 
-        let data = Data(hex: "00112233ffddaa")
         var flags = cryptoFlags
-        let expectedData = Data(hex: "924e38066ef07f36e621a4b12322f68b4620ff9fad0c33")
         do {
-            let returnedData = try sut.encryptData(data, flags: &flags)
-            XCTAssertEqual(returnedData, expectedData)
+            let returnedData = try sut.encryptData(plainData, flags: &flags)
+            XCTAssertEqual(returnedData, encryptedData)
         } catch {
             XCTFail("Cannot encrypt: \(error)")
+        }
+    }
+
+    func test_givenEncrypted_whenDecrypt_thenDecrypts() {
+        let sut = CryptoAEAD(cipherName: "aes-256-gcm")
+        sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+
+        var flags = cryptoFlags
+        do {
+            let returnedData = try sut.decryptData(encryptedData, flags: &flags)
+            XCTAssertEqual(returnedData, plainData)
+        } catch {
+            XCTFail("Cannot decrypt: \(error)")
         }
     }
 

--- a/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
@@ -47,8 +47,6 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.encryptData(plainData, flags: &flags)
-            print("CBC got: \(returnedData.toHex())")
-            print("CBC exp: \(plainHMACData.toHex())")
             XCTAssertEqual(returnedData, plainHMACData)
         } catch {
             XCTFail("Cannot encrypt: \(error)")
@@ -62,8 +60,6 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.encryptData(plainData, flags: &flags)
-            print("CBC got: \(returnedData.toHex())")
-            print("CBC exp: \(encryptedHMACData.toHex())")
             XCTAssertEqual(returnedData, encryptedHMACData)
         } catch {
             XCTFail("Cannot encrypt: \(error)")
@@ -77,8 +73,6 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.decryptData(plainHMACData, flags: &flags)
-            print("CBC got: \(returnedData.toHex())")
-            print("CBC exp: \(plainData.toHex())")
             XCTAssertEqual(returnedData, plainData)
         } catch {
             XCTFail("Cannot decrypt: \(error)")
@@ -92,8 +86,6 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.decryptData(encryptedHMACData, flags: &flags)
-            print("CBC got: \(returnedData.toHex())")
-            print("CBC exp: \(plainData.toHex())")
             XCTAssertEqual(returnedData, plainData)
         } catch {
             XCTFail("Cannot decrypt: \(error)")

--- a/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
@@ -1,0 +1,79 @@
+//
+//  CryptoCBCTests.swift
+//  TunnelKitOpenVPNTests
+//
+//  Created by Davide De Rosa on 12/12/23.
+//  Copyright (c) 2023 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of TunnelKit.
+//
+//  TunnelKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  TunnelKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with TunnelKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import TunnelKitCore
+@testable import TunnelKitOpenVPNCore
+import CTunnelKitCore
+import CTunnelKitOpenVPNProtocol
+
+class CryptoCBCTests: XCTestCase {
+    private let cipherKey = ZeroingData(string: "aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff", nullTerminated: false)
+
+    private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
+
+    func test_whenEncrypt_thenHMACMatches() {
+        let sut = CryptoCBC(cipherName: nil, digestName: "sha256")
+        sut.configureEncryption(withCipherKey: nil, hmacKey: hmacKey)
+
+        let data = Data(hex: "00112233ffddaa")
+        let expectedData = Data(hex: "1d7c9d9d5aa411d18a8416e10a3c8f13c6e6941eeb3b81698496be034bf5113600112233ffddaa")
+        do {
+            let returnedData = try sut.encryptData(data, flags: nil)
+            XCTAssertEqual(returnedData, expectedData)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+        }
+    }
+
+    func test_whenEncrypt_thenResultMatches() {
+        let sut = CryptoCBC(cipherName: "aes-128-cbc", digestName: "sha256")
+        sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+
+        let data = Data(hex: "00112233ffddaa")
+        var flags = cryptoFlags
+        let expectedData = Data(hex: "24be983962e4b4aeacb5734522e37f90f6669e0cfd7f8ab962587dc97d1f600e000000000000000000000000000000003c76480bad5e953ca1211ef83f5594c6")
+        do {
+            let returnedData = try sut.encryptData(data, flags: &flags)
+            XCTAssertEqual(returnedData, expectedData)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+        }
+    }
+
+    private var cryptoFlags: CryptoFlags {
+        let packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
+        let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
+        return packetId.withUnsafeBufferPointer { (iv) in
+            ad.withUnsafeBufferPointer { (ad) in
+                return CryptoFlags(iv: iv.baseAddress,
+                                   ivLength: packetId.count,
+                                   ad: ad.baseAddress,
+                                   adLength: ad.count,
+                                   forTesting: true)
+            }
+        }
+    }
+}

--- a/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
@@ -30,15 +30,15 @@ import CTunnelKitCore
 import CTunnelKitOpenVPNProtocol
 
 class CryptoCBCTests: XCTestCase {
-    private let cipherKey = ZeroingData(string: "aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff", nullTerminated: false)
+    private let cipherKey = ZeroingData(count: 16)
 
-    private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
+    private let hmacKey = ZeroingData(count: 32)
 
     private let plainData = Data(hex: "00112233ffddaa")
 
-    private let plainHMACData = Data(hex: "1d7c9d9d5aa411d18a8416e10a3c8f13c6e6941eeb3b81698496be034bf5113600112233ffddaa")
+    private let plainHMACData = Data(hex: "8dd324c81ca32f52e4aa1aa35139deba799a68460e80b0e5ac8bceb043edf6e500112233ffddaa")
 
-    private let encryptedHMACData = Data(hex: "24be983962e4b4aeacb5734522e37f90f6669e0cfd7f8ab962587dc97d1f600e000000000000000000000000000000003c76480bad5e953ca1211ef83f5594c6")
+    private let encryptedHMACData = Data(hex: "fea3fe87ee68eb21c697e62d3c29f7bea2f5b457d9a7fa66291322fc9c2fe6f700000000000000000000000000000000ebe197e706c3c5dcad026f4e3af1048b")
 
     func test_givenDecrypted_whenEncryptWithoutCipher_thenEncodesWithHMAC() {
         let sut = CryptoCBC(cipherName: nil, digestName: "sha256")
@@ -47,6 +47,8 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.encryptData(plainData, flags: &flags)
+            print("CBC got: \(returnedData.toHex())")
+            print("CBC exp: \(plainHMACData.toHex())")
             XCTAssertEqual(returnedData, plainHMACData)
         } catch {
             XCTFail("Cannot encrypt: \(error)")
@@ -60,6 +62,8 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.encryptData(plainData, flags: &flags)
+            print("CBC got: \(returnedData.toHex())")
+            print("CBC exp: \(encryptedHMACData.toHex())")
             XCTAssertEqual(returnedData, encryptedHMACData)
         } catch {
             XCTFail("Cannot encrypt: \(error)")
@@ -73,6 +77,8 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.decryptData(plainHMACData, flags: &flags)
+            print("CBC got: \(returnedData.toHex())")
+            print("CBC exp: \(plainData.toHex())")
             XCTAssertEqual(returnedData, plainData)
         } catch {
             XCTFail("Cannot decrypt: \(error)")
@@ -86,6 +92,8 @@ class CryptoCBCTests: XCTestCase {
         var flags = cryptoFlags
         do {
             let returnedData = try sut.decryptData(encryptedHMACData, flags: &flags)
+            print("CBC got: \(returnedData.toHex())")
+            print("CBC exp: \(plainData.toHex())")
             XCTAssertEqual(returnedData, plainData)
         } catch {
             XCTFail("Cannot decrypt: \(error)")

--- a/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
@@ -92,6 +92,15 @@ class CryptoCBCTests: XCTestCase {
         }
     }
 
+    func test_givenHMAC_thenVerifies() {
+        let sut = CryptoCBC(cipherName: nil, digestName: "sha256")
+        sut.configureDecryption(withCipherKey: nil, hmacKey: hmacKey)
+
+        var flags = cryptoFlags
+        XCTAssertNoThrow(try sut.verifyData(plainHMACData, flags: &flags))
+        XCTAssertNoThrow(try sut.verifyData(encryptedHMACData, flags: &flags))
+    }
+
     private var cryptoFlags: CryptoFlags {
         let packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
         let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]

--- a/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
@@ -34,18 +34,33 @@ class CryptoCTRTests: XCTestCase {
 
     private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
 
-    func test_whenEncrypt_thenResultMatches() {
+    private let plainData = Data(hex: "00112233ffddaa")
+
+    private let encryptedData = Data(hex: "52c3a656f80491ef706a3f82eb403e87552c447523fd06e472f6986f74ddf404610c86d72c68df")
+
+    func test_givenDecrypted_whenEncrypt_thenEncrypts() {
         let sut = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
         sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
 
-        let data = Data(hex: "00112233ffddaa")
         var flags = cryptoFlags
-        let expectedData = Data(hex: "52c3a656f80491ef706a3f82eb403e87552c447523fd06e472f6986f74ddf404610c86d72c68df")
         do {
-            let returnedData = try sut.encryptData(data, flags: &flags)
-            XCTAssertEqual(returnedData, expectedData)
+            let returnedData = try sut.encryptData(plainData, flags: &flags)
+            XCTAssertEqual(returnedData, encryptedData)
         } catch {
             XCTFail("Cannot encrypt: \(error)")
+        }
+    }
+
+    func test_givenEncrypted_whenDecrypt_thenDecrypts() {
+        let sut = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
+        sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+
+        var flags = cryptoFlags
+        do {
+            let returnedData = try sut.decryptData(encryptedData, flags: &flags)
+            XCTAssertEqual(returnedData, plainData)
+        } catch {
+            XCTFail("Cannot decrypt: \(error)")
         }
     }
 

--- a/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
@@ -30,32 +30,25 @@ import CTunnelKitCore
 import CTunnelKitOpenVPNProtocol
 
 class CryptoCTRTests: XCTestCase {
-    private let cipherKey = ZeroingData(string: "aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff", nullTerminated: false)
+    private let cipherKey = ZeroingData(count: 16)
 
-    private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
+    private let hmacKey = ZeroingData(count: 32)
 
     private let plainData = Data(hex: "00112233ffddaa")
 
-    private let encryptedData = Data(hex: "52c3a656f80491ef706a3f82eb403e87552c447523fd06e472f6986f74ddf404610c86d72c68df")
-
-    func test_givenDecrypted_whenEncrypt_thenEncrypts() {
+    func test_givenData_whenEncrypt_thenDecrypts() {
         let sut = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
         sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
-
-        var flags = cryptoFlags
-        do {
-            let returnedData = try sut.encryptData(plainData, flags: &flags)
-            XCTAssertEqual(returnedData, encryptedData)
-        } catch {
-            XCTFail("Cannot encrypt: \(error)")
-        }
-    }
-
-    func test_givenEncrypted_whenDecrypt_thenDecrypts() {
-        let sut = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
         sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
 
         var flags = cryptoFlags
+        let encryptedData: Data
+        do {
+            encryptedData = try sut.encryptData(plainData, flags: &flags)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+            return
+        }
         do {
             let returnedData = try sut.decryptData(encryptedData, flags: &flags)
             XCTAssertEqual(returnedData, plainData)

--- a/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
@@ -1,0 +1,65 @@
+//
+//  CryptoCTRTests.swift
+//  TunnelKitOpenVPNTests
+//
+//  Created by Davide De Rosa on 12/12/23.
+//  Copyright (c) 2023 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of TunnelKit.
+//
+//  TunnelKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  TunnelKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with TunnelKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import TunnelKitCore
+@testable import TunnelKitOpenVPNCore
+import CTunnelKitCore
+import CTunnelKitOpenVPNProtocol
+
+class CryptoCTRTests: XCTestCase {
+    private let cipherKey = ZeroingData(string: "aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff", nullTerminated: false)
+
+    private let hmacKey = ZeroingData(string: "0011223344556677001122334455667700112233445566770011223344556677", nullTerminated: false)
+
+    func test_whenEncrypt_thenResultMatches() {
+        let sut = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
+        sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+
+        let data = Data(hex: "00112233ffddaa")
+        var flags = cryptoFlags
+        let expectedData = Data(hex: "52c3a656f80491ef706a3f82eb403e87552c447523fd06e472f6986f74ddf404610c86d72c68df")
+        do {
+            let returnedData = try sut.encryptData(data, flags: &flags)
+            XCTAssertEqual(returnedData, expectedData)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+        }
+    }
+
+    private var cryptoFlags: CryptoFlags {
+        let packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
+        let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
+        return packetId.withUnsafeBufferPointer { (iv) in
+            ad.withUnsafeBufferPointer { (ad) in
+                return CryptoFlags(iv: iv.baseAddress,
+                                   ivLength: packetId.count,
+                                   ad: ad.baseAddress,
+                                   adLength: ad.count,
+                                   forTesting: true)
+            }
+        }
+    }
+}

--- a/Tests/TunnelKitOpenVPNTests/DataPathEncryptionTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/DataPathEncryptionTests.swift
@@ -108,9 +108,7 @@ class DataPathEncryptionTests: XCTestCase {
         let key: UInt8 = 4
 
         let encrypted = try! path.encryptPackets([expectedPayload], key: key)
-        print(encrypted.map { $0.toHex() })
         let decrypted = try! path.decryptPackets(encrypted, keepAlive: nil)
-        print(decrypted.map { $0.toHex() })
         let payload = decrypted.first!
 
         XCTAssertEqual(payload, expectedPayload)

--- a/Tests/TunnelKitOpenVPNTests/DataPathPerformanceTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/DataPathPerformanceTests.swift
@@ -82,7 +82,6 @@ class DataPathPerformanceTests: XCTestCase {
 //            decryptedPackets = try! self.swiftDP.decryptPackets(encryptedPackets, keepAlive: nil)
 //        }
 //        
-////        print(">>> \(packets?.count) packets")
 //        XCTAssertEqual(decryptedPackets, packets)
 //    }
 
@@ -97,7 +96,6 @@ class DataPathPerformanceTests: XCTestCase {
             decryptedPackets = try! self.dataPath.decryptPackets(encryptedPackets, keepAlive: nil)
         }
 
-//        print(">>> \(packets?.count) packets")
         XCTAssertEqual(decryptedPackets, packets)
     }
 }

--- a/Tests/TunnelKitOpenVPNTests/EncryptionPerformanceTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/EncryptionPerformanceTests.swift
@@ -82,7 +82,11 @@ class EncryptionPerformanceTests: XCTestCase {
         let suite = TestUtils.generateDataSuite(1000, 100000)
         let ad: [UInt8] = [0x11, 0x22, 0x33, 0x44]
         var flags = ad.withUnsafeBufferPointer {
-            return CryptoFlags(iv: nil, ivLength: 0, ad: $0.baseAddress, adLength: ad.count)
+            return CryptoFlags(iv: nil,
+                               ivLength: 0,
+                               ad: $0.baseAddress,
+                               adLength: ad.count,
+                               forTesting: true)
         }
         measure {
             for data in suite {

--- a/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
@@ -84,7 +84,11 @@ class EncryptionTests: XCTestCase {
         let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
         var flags = packetId.withUnsafeBufferPointer { (iv) in
             return ad.withUnsafeBufferPointer { (ad) in
-                return CryptoFlags(iv: iv.baseAddress, ivLength: packetId.count, ad: ad.baseAddress, adLength: ad.count)
+                return CryptoFlags(iv: iv.baseAddress,
+                                   ivLength: packetId.count,
+                                   ad: ad.baseAddress,
+                                   adLength: ad.count,
+                                   forTesting: true)
             }
         }
         let plain = Data(hex: "00112233445566778899")
@@ -99,7 +103,11 @@ class EncryptionTests: XCTestCase {
         let original = Data(hex: "0000000000")
         let ad: [UInt8] = [UInt8](Data(hex: "38afa8f1162096081e000000015ba35373"))
         var flags = ad.withUnsafeBufferPointer {
-            CryptoFlags(iv: nil, ivLength: 0, ad: $0.baseAddress, adLength: ad.count)
+            CryptoFlags(iv: nil,
+                        ivLength: 0,
+                        ad: $0.baseAddress,
+                        adLength: ad.count,
+                        forTesting: true)
         }
 
 //        let expEncrypted = Data(hex: "319bb8e7f8f7930cc4625079dd32a6ef9540c2fc001c53f909f712037ae9818af840b88714")

--- a/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
@@ -112,11 +112,9 @@ class EncryptionTests: XCTestCase {
 
 //        let expEncrypted = Data(hex: "319bb8e7f8f7930cc4625079dd32a6ef9540c2fc001c53f909f712037ae9818af840b88714")
         let encrypted = try! client.encrypter().encryptData(original, flags: &flags)
-        print(encrypted.toHex())
 //        XCTAssertEqual(encrypted, expEncrypted)
 
         let decrypted = try! server.decrypter().decryptData(encrypted, flags: &flags)
-        print(decrypted.toHex())
         XCTAssertEqual(decrypted, original)
     }
 
@@ -124,7 +122,6 @@ class EncryptionTests: XCTestCase {
         let path = Bundle.module.path(forResource: "pia-2048", ofType: "pem")!
         let md5 = try! TLSBox.md5(forCertificatePath: path)
         let exp = "e2fccccaba712ccc68449b1c56427ac1"
-        print(md5)
         XCTAssertEqual(md5, exp)
     }
 
@@ -140,10 +137,8 @@ class EncryptionTests: XCTestCase {
 
         XCTAssertThrowsError(try TLSBox.decryptedPrivateKey(fromPath: encryptedPath, passphrase: "wrongone"))
         let decryptedViaPath = try! TLSBox.decryptedPrivateKey(fromPath: encryptedPath, passphrase: "foobar")
-        print(decryptedViaPath)
         let encryptedPEM = try! String(contentsOfFile: encryptedPath, encoding: .utf8)
         let decryptedViaString = try! TLSBox.decryptedPrivateKey(fromPEM: encryptedPEM, passphrase: "foobar")
-        print(decryptedViaString)
         XCTAssertEqual(decryptedViaPath, decryptedViaString)
 
         let expDecrypted = try! String(contentsOfFile: decryptedPath)

--- a/Tests/TunnelKitOpenVPNTests/LinkTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/LinkTests.swift
@@ -152,7 +152,6 @@ class LinkTests: XCTestCase {
             enqueueControl(&q, &id, p) {
                 hdl.append($0)
             }
-            print()
         }
         return hdl
     }
@@ -163,10 +162,7 @@ class LinkTests: XCTestCase {
             return (p1 < p2)
         }
 
-        print("q = \(q)")
-        print("id = \(id)")
         for p in q {
-            print("test(\(p))")
             if p < id {
                 q.removeFirst()
                 continue
@@ -176,7 +172,6 @@ class LinkTests: XCTestCase {
             }
 
             h(p)
-            print("handle(\(p))")
             id += 1
             q.removeFirst()
         }

--- a/Tests/TunnelKitOpenVPNTests/PacketTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/PacketTests.swift
@@ -48,8 +48,6 @@ class PacketTests: XCTestCase {
 
         let serialized = ControlPacket(code: code, key: key, sessionId: sessionId, packetId: id, payload: payload).serialized()
         let expected = Data(hex: "2311223344556677880000001456932748238742397591704891")
-        print("Serialized: \(serialized.toHex())")
-        print("Expected  : \(expected.toHex())")
 
         XCTAssertEqual(serialized, expected)
     }
@@ -62,8 +60,6 @@ class PacketTests: XCTestCase {
 
         let serialized = ControlPacket(key: key, sessionId: sessionId, ackIds: acks as [NSNumber], ackRemoteSessionId: remoteSessionId).serialized()
         let expected = Data(hex: "2b112233445566778805000000aa000000bb000000cc000000dd000000eea639328cbf03490e")
-        print("Serialized: \(serialized.toHex())")
-        print("Expected  : \(expected.toHex())")
 
         XCTAssertEqual(serialized, expected)
     }

--- a/Tests/TunnelKitOpenVPNTests/PushTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/PushTests.swift
@@ -31,11 +31,6 @@ import XCTest
 
 private extension OpenVPN.PushReply {
     func debug() {
-        print("Compression framing: \(options.compressionFraming?.description ?? "disabled")")
-        print("Compression algorithm: \(options.compressionAlgorithm?.description ?? "disabled")")
-        print("IPv4: \(options.ipv4?.description ?? "none")")
-        print("IPv6: \(options.ipv6?.description ?? "none")")
-        print("DNS: \(options.dnsServers?.description ?? "none")")
     }
 }
 
@@ -174,7 +169,6 @@ class PushTests: XCTestCase {
     }
 
     func testPeerInfo() {
-        let peerInfo = CoreConfiguration.OpenVPN.peerInfo()
-        print(peerInfo)
+        _ = CoreConfiguration.OpenVPN.peerInfo()
     }
 }


### PR DESCRIPTION
Encryption tests are too vague. Focus on OpenSSL-dependent entities for [migration to version 3](https://github.com/passepartoutvpn/tunnelkit/issues/336):

- CBC
- CTR
- AEAD