### PR TITLE
Dangling pointers in crypto tests

### DIFF
--- a/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
@@ -65,7 +65,7 @@ class CryptoAEADTests: XCTestCase {
         return packetId.withUnsafeBufferPointer { iv in
             ad.withUnsafeBufferPointer { ad in
                 CryptoFlags(iv: iv.baseAddress,
-                            ivLength: packetId.count,
+                            ivLength: iv.count,
                             ad: ad.baseAddress,
                             adLength: ad.count,
                             forTesting: true)

--- a/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoAEADTests.swift
@@ -36,32 +36,11 @@ class CryptoAEADTests: XCTestCase {
 
     private let plainData = Data(hex: "00112233ffddaa")
 
-    func test_givenData_whenEncrypt_thenDecrypts() {
-        let encryptedData: Data
-        var flags = cryptoFlags
+    private var packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
 
-        let sut1 = CryptoAEAD(cipherName: "aes-256-gcm")
-        sut1.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
-        do {
-            encryptedData = try sut1.encryptData(plainData, flags: &flags)
-        } catch {
-            XCTFail("Cannot encrypt: \(error)")
-            return
-        }
+    private var ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
 
-        let sut2 = CryptoAEAD(cipherName: "aes-256-gcm")
-        sut2.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
-        do {
-            let returnedData = try sut2.decryptData(encryptedData, flags: &flags)
-            XCTAssertEqual(returnedData, plainData)
-        } catch {
-            XCTFail("Cannot decrypt: \(error)")
-        }
-    }
-
-    private var cryptoFlags: CryptoFlags {
-        let packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
-        let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
+    private lazy var flags: CryptoFlags = {
         return packetId.withUnsafeBufferPointer { iv in
             ad.withUnsafeBufferPointer { ad in
                 CryptoFlags(iv: iv.baseAddress,
@@ -70,6 +49,26 @@ class CryptoAEADTests: XCTestCase {
                             adLength: ad.count,
                             forTesting: true)
             }
+        }
+    }()
+
+    func test_givenData_whenEncrypt_thenDecrypts() {
+        let sut = CryptoAEAD(cipherName: "aes-256-gcm")
+        sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+        sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+        let encryptedData: Data
+
+        do {
+            encryptedData = try sut.encryptData(plainData, flags: &flags)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+            return
+        }
+        do {
+            let returnedData = try sut.decryptData(encryptedData, flags: &flags)
+            XCTAssertEqual(returnedData, plainData)
+        } catch {
+            XCTFail("Cannot decrypt: \(error)")
         }
     }
 }

--- a/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
@@ -40,11 +40,26 @@ class CryptoCBCTests: XCTestCase {
 
     private let encryptedHMACData = Data(hex: "fea3fe87ee68eb21c697e62d3c29f7bea2f5b457d9a7fa66291322fc9c2fe6f700000000000000000000000000000000ebe197e706c3c5dcad026f4e3af1048b")
 
+    private var packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
+
+    private var ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
+
+    private lazy var flags: CryptoFlags = {
+        return packetId.withUnsafeBufferPointer { iv in
+            ad.withUnsafeBufferPointer { ad in
+                CryptoFlags(iv: iv.baseAddress,
+                            ivLength: iv.count,
+                            ad: ad.baseAddress,
+                            adLength: ad.count,
+                            forTesting: true)
+            }
+        }
+    }()
+
     func test_givenDecrypted_whenEncryptWithoutCipher_thenEncodesWithHMAC() {
         let sut = CryptoCBC(cipherName: nil, digestName: "sha256")
         sut.configureEncryption(withCipherKey: nil, hmacKey: hmacKey)
 
-        var flags = cryptoFlags
         do {
             let returnedData = try sut.encryptData(plainData, flags: &flags)
             XCTAssertEqual(returnedData, plainHMACData)
@@ -57,7 +72,6 @@ class CryptoCBCTests: XCTestCase {
         let sut = CryptoCBC(cipherName: "aes-128-cbc", digestName: "sha256")
         sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
 
-        var flags = cryptoFlags
         do {
             let returnedData = try sut.encryptData(plainData, flags: &flags)
             XCTAssertEqual(returnedData, encryptedHMACData)
@@ -70,7 +84,6 @@ class CryptoCBCTests: XCTestCase {
         let sut = CryptoCBC(cipherName: nil, digestName: "sha256")
         sut.configureDecryption(withCipherKey: nil, hmacKey: hmacKey)
 
-        var flags = cryptoFlags
         do {
             let returnedData = try sut.decryptData(plainHMACData, flags: &flags)
             XCTAssertEqual(returnedData, plainData)
@@ -83,7 +96,6 @@ class CryptoCBCTests: XCTestCase {
         let sut = CryptoCBC(cipherName: "aes-128-cbc", digestName: "sha256")
         sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
 
-        var flags = cryptoFlags
         do {
             let returnedData = try sut.decryptData(encryptedHMACData, flags: &flags)
             XCTAssertEqual(returnedData, plainData)
@@ -96,22 +108,7 @@ class CryptoCBCTests: XCTestCase {
         let sut = CryptoCBC(cipherName: nil, digestName: "sha256")
         sut.configureDecryption(withCipherKey: nil, hmacKey: hmacKey)
 
-        var flags = cryptoFlags
         XCTAssertNoThrow(try sut.verifyData(plainHMACData, flags: &flags))
         XCTAssertNoThrow(try sut.verifyData(encryptedHMACData, flags: &flags))
-    }
-
-    private var cryptoFlags: CryptoFlags {
-        let packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
-        let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
-        return packetId.withUnsafeBufferPointer { iv in
-            ad.withUnsafeBufferPointer { ad in
-                CryptoFlags(iv: iv.baseAddress,
-                            ivLength: iv.count,
-                            ad: ad.baseAddress,
-                            adLength: ad.count,
-                            forTesting: true)
-            }
-        }
     }
 }

--- a/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCBCTests.swift
@@ -107,7 +107,7 @@ class CryptoCBCTests: XCTestCase {
         return packetId.withUnsafeBufferPointer { iv in
             ad.withUnsafeBufferPointer { ad in
                 CryptoFlags(iv: iv.baseAddress,
-                            ivLength: packetId.count,
+                            ivLength: iv.count,
                             ad: ad.baseAddress,
                             adLength: ad.count,
                             forTesting: true)

--- a/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
@@ -36,32 +36,11 @@ class CryptoCTRTests: XCTestCase {
 
     private let plainData = Data(hex: "00112233ffddaa")
 
-    func test_givenData_whenEncrypt_thenDecrypts() {
-        let encryptedData: Data
-        var flags = cryptoFlags
+    private var packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
 
-        let sut1 = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
-        sut1.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
-        do {
-            encryptedData = try sut1.encryptData(plainData, flags: &flags)
-        } catch {
-            XCTFail("Cannot encrypt: \(error)")
-            return
-        }
+    private var ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
 
-        let sut2 = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
-        sut2.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
-        do {
-            let returnedData = try sut2.decryptData(encryptedData, flags: &flags)
-            XCTAssertEqual(returnedData, plainData)
-        } catch {
-            XCTFail("Cannot decrypt: \(error)")
-        }
-    }
-
-    private var cryptoFlags: CryptoFlags {
-        let packetId: [UInt8] = [0x56, 0x34, 0x12, 0x00]
-        let ad: [UInt8] = [0x00, 0x12, 0x34, 0x56]
+    private lazy var flags: CryptoFlags = {
         return packetId.withUnsafeBufferPointer { iv in
             ad.withUnsafeBufferPointer { ad in
                 CryptoFlags(iv: iv.baseAddress,
@@ -70,6 +49,26 @@ class CryptoCTRTests: XCTestCase {
                             adLength: ad.count,
                             forTesting: true)
             }
+        }
+    }()
+
+    func test_givenData_whenEncrypt_thenDecrypts() {
+        let sut = CryptoCTR(cipherName: "aes-128-ctr", digestName: "sha256")
+        sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+        sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
+        let encryptedData: Data
+
+        do {
+            encryptedData = try sut.encryptData(plainData, flags: &flags)
+        } catch {
+            XCTFail("Cannot encrypt: \(error)")
+            return
+        }
+        do {
+            let returnedData = try sut.decryptData(encryptedData, flags: &flags)
+            XCTAssertEqual(returnedData, plainData)
+        } catch {
+            XCTFail("Cannot decrypt: \(error)")
         }
     }
 }

--- a/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/CryptoCTRTests.swift
@@ -65,7 +65,7 @@ class CryptoCTRTests: XCTestCase {
         return packetId.withUnsafeBufferPointer { iv in
             ad.withUnsafeBufferPointer { ad in
                 CryptoFlags(iv: iv.baseAddress,
-                            ivLength: packetId.count,
+                            ivLength: iv.count,
                             ad: ad.baseAddress,
                             adLength: ad.count,
                             forTesting: true)

--- a/Tests/TunnelKitOpenVPNTests/EncryptionPerformanceTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/EncryptionPerformanceTests.swift
@@ -85,7 +85,7 @@ class EncryptionPerformanceTests: XCTestCase {
             CryptoFlags(iv: nil,
                         ivLength: 0,
                         ad: $0.baseAddress,
-                        adLength: ad.count,
+                        adLength: $0.count,
                         forTesting: true)
         }
         measure {

--- a/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
+++ b/Tests/TunnelKitOpenVPNTests/EncryptionTests.swift
@@ -85,7 +85,7 @@ class EncryptionTests: XCTestCase {
         var flags = packetId.withUnsafeBufferPointer { iv in
             ad.withUnsafeBufferPointer { ad in
                 CryptoFlags(iv: iv.baseAddress,
-                            ivLength: packetId.count,
+                            ivLength: iv.count,
                             ad: ad.baseAddress,
                             adLength: ad.count,
                             forTesting: true)
@@ -106,7 +106,7 @@ class EncryptionTests: XCTestCase {
             CryptoFlags(iv: nil,
                         ivLength: 0,
                         ad: $0.baseAddress,
-                        adLength: ad.count,
+                        adLength: $0.count,
                         forTesting: true)
         }
 


### PR DESCRIPTION
A ridiculous slip-up in #348 has made the outcome of those tests unpredictable, and that's because CryptoFlags is referencing local variables. Fix that sh*t.