### PR TITLE
Fix regression in mapping OpenVPN errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Bad mapping of OpenVPN errors. [#404](https://github.com/passepartoutvpn/tunnelkit/pull/404)
+
 ## 6.3.1 (2024-01-05)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bad mapping of OpenVPN errors. [#404](https://github.com/passepartoutvpn/tunnelkit/pull/404)
+- OpenVPN: Bad error mapping. [#404](https://github.com/passepartoutvpn/tunnelkit/pull/404)
 
 ## 6.3.1 (2024-01-05)
 

--- a/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
+++ b/Sources/TunnelKitOpenVPNAppExtension/OpenVPNTunnelProvider.swift
@@ -684,8 +684,8 @@ private extension OpenVPNTunnelProvider {
     }
 
     func openVPNError(from error: Error) -> TunnelKitOpenVPNError? {
-        if let specificError = error as? OpenVPNError {
-            switch specificError.asNativeOpenVPNError ?? specificError {
+        if let specificError = error.asNativeOpenVPNError ?? error as? OpenVPNError {
+            switch specificError {
             case .negotiationTimeout, .pingTimeout, .staleSession:
                 return .timeout
 


### PR DESCRIPTION
There is a wrong condition when mapping OpenVPN errors. Specifically, those coming from the C/ObjC layer are being discarded.

E.g. TLS errors appear as .linkError and "Network changed" in Passepartout.