### PR TITLE
HMAC breaking due to dangling OSSL_PARAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- OpenVPN: HMAC breaking due to dangling OSSL_PARAM. [#405](https://github.com/passepartoutvpn/tunnelkit/pull/405)
+
 ## 6.3.1 (2024-01-05)
 
 ### Changed

--- a/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
+++ b/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
@@ -50,6 +50,8 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
 
 @property (nonatomic, unsafe_unretained) const EVP_CIPHER *cipher;
 @property (nonatomic, unsafe_unretained) const EVP_MD *digest;
+@property (nonatomic, unsafe_unretained) const char *cCipherName;
+@property (nonatomic, unsafe_unretained) const char *cDigestName;
 @property (nonatomic, assign) int cipherKeyLength;
 @property (nonatomic, assign) int cipherIVLength;
 @property (nonatomic, assign) int hmacKeyLength;
@@ -75,10 +77,14 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
     self = [super init];
     if (self) {
         if (cipherName) {
-            self.cipher = EVP_get_cipherbyname([cipherName cStringUsingEncoding:NSASCIIStringEncoding]);
+            self.cCipherName = calloc([cipherName length] + 1, sizeof(char));
+            strncpy(self.cCipherName, [cipherName cStringUsingEncoding:NSASCIIStringEncoding], [cipherName length]);
+            self.cipher = EVP_get_cipherbyname(self.cCipherName);
             NSAssert(self.cipher, @"Unknown cipher '%@'", cipherName);
         }
-        self.digest = EVP_get_digestbyname([digestName cStringUsingEncoding:NSASCIIStringEncoding]);
+        self.cDigestName = calloc([digestName length] + 1, sizeof(char));
+        strncpy(self.cDigestName, [digestName cStringUsingEncoding:NSASCIIStringEncoding], [digestName length]);
+        self.digest = EVP_get_digestbyname(self.cDigestName);
         NSAssert(self.digest, @"Unknown digest '%@'", digestName);
 
         if (cipherName) {
@@ -96,7 +102,7 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
 
         self.mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
         OSSL_PARAM *macParams = calloc(2, sizeof(OSSL_PARAM));
-        macParams[0] = OSSL_PARAM_construct_utf8_string("digest", (char *)[digestName cStringUsingEncoding:NSASCIIStringEncoding], 0);
+        macParams[0] = OSSL_PARAM_construct_utf8_string("digest", self.cDigestName, 0);
         macParams[1] = OSSL_PARAM_construct_end();
         self.macParams = macParams;
 
@@ -115,7 +121,12 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
     free(self.macParams);
     bzero(self.bufferDecHMAC, CryptoCBCMaxHMACLength);
     free(self.bufferDecHMAC);
-    
+
+    if (self.cCipherName) {
+        free(self.cCipherName);
+    }
+    free(self.cDigestName);
+
     self.cipher = NULL;
     self.digest = NULL;
 }
@@ -175,7 +186,6 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
         memcpy(outEncrypted, bytes, length);
         l1 = (int)length;
     }
-    
     EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(self.mac);
     TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_MAC_init(ctx, self.hmacKeyEnc.bytes, self.hmacKeyEnc.count, self.macParams);
     TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_MAC_update(ctx, outIV, l1 + l2 + self.cipherIVLength);
@@ -215,7 +225,7 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
     const uint8_t *encrypted = bytes + self.digestLength + self.cipherIVLength;
     size_t l1 = 0, l2 = 0;
     int code = 1;
-    
+
     EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(self.mac);
     TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_MAC_init(ctx, self.hmacKeyDec.bytes, self.hmacKeyDec.count, self.macParams);
     TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_MAC_update(ctx, bytes + self.digestLength, length - self.digestLength);
@@ -249,7 +259,7 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
 {
     size_t l1 = 0;
     int code = 1;
-    
+
     EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(self.mac);
     TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_MAC_init(ctx, self.hmacKeyDec.bytes, self.hmacKeyDec.count, self.macParams);
     TUNNEL_CRYPTO_TRACK_STATUS(code) EVP_MAC_update(ctx, bytes + self.digestLength, length - self.digestLength);

--- a/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
+++ b/Sources/CTunnelKitOpenVPNProtocol/CryptoCBC.m
@@ -50,8 +50,8 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
 
 @property (nonatomic, unsafe_unretained) const EVP_CIPHER *cipher;
 @property (nonatomic, unsafe_unretained) const EVP_MD *digest;
-@property (nonatomic, unsafe_unretained) const char *cCipherName;
-@property (nonatomic, unsafe_unretained) const char *cDigestName;
+@property (nonatomic, unsafe_unretained) const char *utfCipherName;
+@property (nonatomic, unsafe_unretained) const char *utfDigestName;
 @property (nonatomic, assign) int cipherKeyLength;
 @property (nonatomic, assign) int cipherIVLength;
 @property (nonatomic, assign) int hmacKeyLength;
@@ -77,14 +77,14 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
     self = [super init];
     if (self) {
         if (cipherName) {
-            self.cCipherName = calloc([cipherName length] + 1, sizeof(char));
-            strncpy(self.cCipherName, [cipherName cStringUsingEncoding:NSASCIIStringEncoding], [cipherName length]);
-            self.cipher = EVP_get_cipherbyname(self.cCipherName);
+            self.utfCipherName = calloc([cipherName length] + 1, sizeof(char));
+            strncpy(self.utfCipherName, [cipherName UTF8String], [cipherName length]);
+            self.cipher = EVP_get_cipherbyname(self.utfCipherName);
             NSAssert(self.cipher, @"Unknown cipher '%@'", cipherName);
         }
-        self.cDigestName = calloc([digestName length] + 1, sizeof(char));
-        strncpy(self.cDigestName, [digestName cStringUsingEncoding:NSASCIIStringEncoding], [digestName length]);
-        self.digest = EVP_get_digestbyname(self.cDigestName);
+        self.utfDigestName = calloc([digestName length] + 1, sizeof(char));
+        strncpy(self.utfDigestName, [digestName UTF8String], [digestName length]);
+        self.digest = EVP_get_digestbyname(self.utfDigestName);
         NSAssert(self.digest, @"Unknown digest '%@'", digestName);
 
         if (cipherName) {
@@ -102,7 +102,7 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
 
         self.mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
         OSSL_PARAM *macParams = calloc(2, sizeof(OSSL_PARAM));
-        macParams[0] = OSSL_PARAM_construct_utf8_string("digest", self.cDigestName, 0);
+        macParams[0] = OSSL_PARAM_construct_utf8_string("digest", self.utfDigestName, 0);
         macParams[1] = OSSL_PARAM_construct_end();
         self.macParams = macParams;
 
@@ -122,10 +122,10 @@ const NSInteger CryptoCBCMaxHMACLength = 100;
     bzero(self.bufferDecHMAC, CryptoCBCMaxHMACLength);
     free(self.bufferDecHMAC);
 
-    if (self.cCipherName) {
-        free(self.cCipherName);
+    if (self.utfCipherName) {
+        free(self.utfCipherName);
     }
-    free(self.cDigestName);
+    free(self.utfDigestName);
 
     self.cipher = NULL;
     self.digest = NULL;

--- a/Sources/CTunnelKitOpenVPNProtocol/CryptoCTR.m
+++ b/Sources/CTunnelKitOpenVPNProtocol/CryptoCTR.m
@@ -38,8 +38,8 @@ static const NSInteger CryptoCTRTagLength = 32;
 
 @property (nonatomic, unsafe_unretained) const EVP_CIPHER *cipher;
 @property (nonatomic, unsafe_unretained) const EVP_MD *digest;
-@property (nonatomic, unsafe_unretained) const char *cCipherName;
-@property (nonatomic, unsafe_unretained) const char *cDigestName;
+@property (nonatomic, unsafe_unretained) const char *utfCipherName;
+@property (nonatomic, unsafe_unretained) const char *utfDigestName;
 @property (nonatomic, assign) int cipherKeyLength;
 @property (nonatomic, assign) int cipherIVLength;
 @property (nonatomic, assign) int hmacKeyLength;
@@ -63,14 +63,14 @@ static const NSInteger CryptoCTRTagLength = 32;
     
     self = [super init];
     if (self) {
-        self.cCipherName = calloc([cipherName length] + 1, sizeof(char));
-        strncpy(self.cCipherName, [cipherName cStringUsingEncoding:NSASCIIStringEncoding], [cipherName length]);
-        self.cipher = EVP_get_cipherbyname(self.cCipherName);
+        self.utfCipherName = calloc([cipherName length] + 1, sizeof(char));
+        strncpy(self.utfCipherName, [cipherName UTF8String], [cipherName length]);
+        self.cipher = EVP_get_cipherbyname(self.utfCipherName);
         NSAssert(self.cipher, @"Unknown cipher '%@'", cipherName);
 
-        self.cDigestName = calloc([digestName length] + 1, sizeof(char));
-        strncpy(self.cDigestName, [digestName cStringUsingEncoding:NSASCIIStringEncoding], [digestName length]);
-        self.digest = EVP_get_digestbyname(self.cDigestName);
+        self.utfDigestName = calloc([digestName length] + 1, sizeof(char));
+        strncpy(self.utfDigestName, [digestName UTF8String], [digestName length]);
+        self.digest = EVP_get_digestbyname(self.utfDigestName);
         NSAssert(self.digest, @"Unknown digest '%@'", digestName);
         
         self.cipherKeyLength = EVP_CIPHER_key_length(self.cipher);
@@ -84,7 +84,7 @@ static const NSInteger CryptoCTRTagLength = 32;
 
         self.mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
         OSSL_PARAM *macParams = calloc(2, sizeof(OSSL_PARAM));
-        macParams[0] = OSSL_PARAM_construct_utf8_string("digest", (char *)[digestName cStringUsingEncoding:NSASCIIStringEncoding], 0);
+        macParams[0] = OSSL_PARAM_construct_utf8_string("digest", self.utfDigestName, 0);
         macParams[1] = OSSL_PARAM_construct_end();
         self.macParams = macParams;
 
@@ -102,8 +102,8 @@ static const NSInteger CryptoCTRTagLength = 32;
     bzero(self.bufferDecHMAC, CryptoCTRTagLength);
     free(self.bufferDecHMAC);
 
-    free(self.cCipherName);
-    free(self.cDigestName);
+    free(self.utfCipherName);
+    free(self.utfDigestName);
 
     self.cipher = NULL;
     self.digest = NULL;


### PR DESCRIPTION
In CBC and CTR, the pointer to the HMAC digest name is a `char *` to a deallocated `NSString`, as the digest name is an init argument. This caused all sorts of OpenSSL misbehavior.

Arguably related to #403