### PR TITLE
Set SSL security level explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - OpenVPN: Bad error mapping. [#404](https://github.com/passepartoutvpn/tunnelkit/pull/404)
+- OpenVPN: Restore default security level. [#406](https://github.com/passepartoutvpn/tunnelkit/pull/406)
 
 ## 6.3.1 (2024-01-05)
 

--- a/Sources/CTunnelKitOpenVPNProtocol/TLSBox.m
+++ b/Sources/CTunnelKitOpenVPNProtocol/TLSBox.m
@@ -214,9 +214,7 @@ static BIO *create_BIO_from_PEM(NSString *pem) {
     self.ctx = SSL_CTX_new(TLS_client_method());
     SSL_CTX_set_options(self.ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
     SSL_CTX_set_verify(self.ctx, SSL_VERIFY_PEER, TLSBoxVerifyPeer);
-    if (self.securityLevel != TLSBoxDefaultSecurityLevel) {
-        SSL_CTX_set_security_level(self.ctx, (int)self.securityLevel);
-    }
+    SSL_CTX_set_security_level(self.ctx, (int)self.securityLevel);
 
     if (self.caPath) {
         if (!SSL_CTX_load_verify_locations(self.ctx, [self.caPath cStringUsingEncoding:NSASCIIStringEncoding], NULL)) {


### PR DESCRIPTION
The default value may have been raised in OpenSSL 3, disrupting operations with less secure certificates.

Set it explicitly to 0 by default, in order to restore OpenSSL 1.1.1 behavior.